### PR TITLE
Fix model fetch URL construction

### DIFF
--- a/src/backend/services/model/provider.ts
+++ b/src/backend/services/model/provider.ts
@@ -62,12 +62,13 @@ export async function fetchOpenRouterModels(): Promise<NormalizedModel[]> {
 export async function fetchOpenAIModels(apiKey: string | null, baseUrl: string): Promise<NormalizedModel[]> {
   log.debug('fetchOpenAIModels: Entering method');
   
-  // Ensure baseUrl ends with /v1
+  // Ensure baseUrl ends with /v1 but avoid duplicate /v1/v1
   let modelsUrl = baseUrl;
-  if (!modelsUrl.endsWith('/v1')) {
+  if (!modelsUrl.endsWith('/v1') && !modelsUrl.endsWith('/v1/')) {
     modelsUrl = modelsUrl.endsWith('/') ? `${modelsUrl}v1` : `${modelsUrl}/v1`;
   }
-  modelsUrl = `${modelsUrl}/models`;
+  // Remove trailing slash if present before adding /models
+  modelsUrl = modelsUrl.endsWith('/') ? `${modelsUrl}models` : `${modelsUrl}/models`;
   
   log.debug(`Fetching models from: ${modelsUrl}`);
   


### PR DESCRIPTION
This PR fixes an issue with the model fetch URL construction to avoid duplicate /v1 paths and properly handle trailing slashes when constructing the models URL