### PR TITLE
strip a trailing slash if it exists before adding .git

### DIFF
--- a/src/frontend/components/mcp/MCPServerManager/Modals/ServerModal/utils/gitHubUtils.ts
+++ b/src/frontend/components/mcp/MCPServerManager/Modals/ServerModal/utils/gitHubUtils.ts
@@ -170,9 +170,11 @@ export const cloneRepository = async (
     if (blobMatch) {
       repoUrl = blobMatch[1];
     }
-    
-    const gitCloneUrl = repoUrl.endsWith('.git') ? repoUrl : `${repoUrl}.git`;
-    
+
+    const gitCloneUrl = repoUrl.endsWith('.git')
+      ? repoUrl 
+      : `${repoUrl.replace(/\/$/, '')}.git`;
+
     // Normalize path by replacing backslashes with forward slashes
     const normalizedPath = savePath.replace(/\\/g, '/');
     


### PR DESCRIPTION
Fixes issue cloning mcp server from github if url contains a trailing slash

<img width="797" alt="image" src="https://github.com/user-attachments/assets/912fe807-13a4-4d44-a899-2e9708a44cdf" />
