### PR TITLE
Add Parallel Search MCP to Spotlight

### DIFF
--- a/__tests__/mcp/spotlight.test.ts
+++ b/__tests__/mcp/spotlight.test.ts
@@ -1,0 +1,150 @@
+jest.mock('@/utils/storage/backend', () => ({
+  loadItem: jest.fn(),
+  saveItem: jest.fn(),
+}));
+
+jest.mock('@/backend/utils/registryClient', () => ({
+  REGISTRY_ORIGIN: 'https://registry.modelcontextprotocol.io',
+  registryGetJson: jest.fn(),
+}));
+
+import { loadSpotlightCache, refreshSpotlightServers } from '@/backend/services/spotlight';
+import { registryGetJson } from '@/backend/utils/registryClient';
+import { StorageKey } from '@/shared/types/storage';
+import { loadItem, saveItem } from '@/utils/storage/backend';
+import {
+  SpotlightCache,
+  RegistryServerResult,
+  getInstallOptions,
+  buildConfigFromOption,
+} from '@/utils/mcp/registry';
+
+const SOURCE_URL = 'https://registry.modelcontextprotocol.io/v0.1/servers/ai.parallel%2Fsearch-mcp/versions';
+const OLD_URL = 'https://search-mcp.parallel.ai/mcp';
+const ANONYMOUS_URL = 'https://search.parallel.ai/mcp';
+
+const registryResult = (): RegistryServerResult => ({
+  server: {
+    name: 'ai.parallel/search-mcp',
+    title: 'Parallel Search MCP',
+    version: '1.0.0',
+    remotes: [{ type: 'streamable-http', url: OLD_URL }],
+  },
+  _meta: { 'io.modelcontextprotocol.registry/official': { status: 'active' } },
+});
+
+const cached = (result = registryResult()): SpotlightCache => ({
+  updatedAt: '2026-07-24T00:00:00.000Z',
+  entries: [{ url: SOURCE_URL, result }],
+});
+
+const loadMock = jest.mocked(loadItem);
+const saveMock = jest.mocked(saveItem);
+const registryMock = jest.mocked(registryGetJson);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.__flujo_spotlight_refresh = undefined;
+  loadMock.mockResolvedValue(null);
+  saveMock.mockResolvedValue(undefined);
+});
+
+describe('Spotlight remote endpoint corrections', () => {
+  it('keeps an empty cache empty without fetching the registry', async () => {
+    expect(await loadSpotlightCache()).toBeNull();
+    expect(registryMock).not.toHaveBeenCalled();
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('builds the anonymous Parallel config from an existing cache before any refresh', async () => {
+    const stored = cached();
+    loadMock.mockResolvedValue(stored);
+
+    const cache = await loadSpotlightCache();
+    const server = cache!.entries[0].result!.server;
+    const options = getInstallOptions(server);
+    expect(options).toHaveLength(1);
+    expect(options[0].label).toContain(ANONYMOUS_URL);
+    const config = buildConfigFromOption(server, options[0]);
+    expect(config).toMatchObject({
+      transport: 'streamable',
+      serverUrl: ANONYMOUS_URL,
+      headers: {},
+      source: { type: 'registry', registryName: 'ai.parallel/search-mcp', version: '1.0.0' },
+    });
+    expect(config).not.toHaveProperty('oauthClientId');
+    expect(config).not.toHaveProperty('oauthClientInformation');
+    expect(config).not.toHaveProperty('oauthTokens');
+    expect(cache!.updatedAt).toBe(stored.updatedAt);
+    expect(stored.entries[0].result!.server.remotes![0].url).toBe(OLD_URL);
+    expect(loadMock).toHaveBeenCalledWith(StorageKey.SPOTLIGHT_SERVERS, null);
+    expect(registryMock).not.toHaveBeenCalled();
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('changes only the configured source and exact URL, preserving registry inputs and metadata', async () => {
+    const result = registryResult();
+    result.server.remotes![0].headers = [{ name: 'X-Example', isRequired: true, isSecret: true }];
+    result.server.remotes!.push({ type: 'sse', url: 'https://search.parallel.ai/another-endpoint' });
+    result.server.packages = [{ registryType: 'npm', identifier: 'example-search' }];
+    const stored = cached(result);
+    stored.entries.push(
+      { url: 'https://registry.modelcontextprotocol.io/?q=another-provider', result: registryResult() },
+      { url: 'https://registry.modelcontextprotocol.io/?q=unavailable', error: 'Unavailable' },
+    );
+    const original = JSON.parse(JSON.stringify(stored));
+    loadMock.mockResolvedValue(stored);
+
+    const cache = await loadSpotlightCache();
+    expect(cache!.entries[0].result).toEqual({
+      ...result,
+      server: {
+        ...result.server,
+        remotes: [
+          { ...result.server.remotes![0], url: ANONYMOUS_URL },
+          result.server.remotes![1],
+        ],
+      },
+    });
+    expect(cache!.entries.slice(1)).toEqual(stored.entries.slice(1));
+    expect(stored).toEqual(original);
+  });
+
+  it('returns corrected fresh records while persisting the registry response unchanged', async () => {
+    const result = registryResult();
+    registryMock.mockImplementation(async url => ({
+      servers: [url.searchParams.get('search') === 'ai.parallel/search-mcp'
+        ? result
+        : { server: { name: url.searchParams.get('search')!, remotes: [] } }],
+    }));
+
+    const cache = await refreshSpotlightServers();
+    const entry = cache.entries.find(e => e.url === SOURCE_URL)!;
+    expect(entry.result!.server.remotes![0].url).toBe(ANONYMOUS_URL);
+    expect(entry.error).toBeUndefined();
+    expect(registryMock).toHaveBeenCalledWith(
+      new URL('https://registry.modelcontextprotocol.io/v0.1/servers?search=ai.parallel%2Fsearch-mcp&version=latest&limit=1'),
+      15000,
+    );
+    expect(cache.entries.find(e => e.url.includes('playwright-mcp'))!.env)
+      .toEqual({ PLAYWRIGHT_MCP_BROWSER: 'msedge' });
+    const persisted = saveMock.mock.calls[0][1] as SpotlightCache;
+    expect(saveMock.mock.calls[0][0]).toBe(StorageKey.SPOTLIGHT_SERVERS);
+    expect(persisted.entries.find(e => e.url === SOURCE_URL)!.result).toEqual(registryResult());
+    expect(result).toEqual(registryResult());
+  });
+
+  it('corrects the previous good record after refresh failure without storing the correction', async () => {
+    const stored = cached();
+    loadMock.mockResolvedValue(stored);
+    registryMock.mockRejectedValue(new Error('Registry unavailable'));
+
+    const cache = await refreshSpotlightServers();
+    const entry = cache.entries.find(e => e.url === SOURCE_URL)!;
+    expect(entry.result!.server.remotes![0].url).toBe(ANONYMOUS_URL);
+    expect(entry.error).toBe('Registry unavailable');
+    const persisted = saveMock.mock.calls[0][1] as SpotlightCache;
+    expect(persisted.entries.find(e => e.url === SOURCE_URL)!.result).toEqual(registryResult());
+    expect(stored).toEqual(cached());
+  });
+});

--- a/src/backend/services/spotlight/index.ts
+++ b/src/backend/services/spotlight/index.ts
@@ -34,9 +34,36 @@ declare global {
   var __flujo_spotlight_refresh: Promise<SpotlightCache> | undefined;
 }
 
-/** The cached spotlight data, or null when no refresh has succeeded yet. */
+/** Apply shipped endpoint corrections without mutating cached registry data. */
+function applySourceOverrides(cache: SpotlightCache): SpotlightCache {
+  const sources = SPOTLIGHT_SERVERS.map(normalizeSpotlightSource);
+  return {
+    ...cache,
+    entries: cache.entries.map(entry => {
+      const overrides = sources.find(source => source.url === entry.url)?.remoteUrlOverrides;
+      const result = entry.result;
+      if (!overrides || !result?.server.remotes) return entry;
+      return {
+        ...entry,
+        result: {
+          ...result,
+          server: {
+            ...result.server,
+            remotes: result.server.remotes.map(remote => ({
+              ...remote,
+              url: overrides[remote.url] ?? remote.url
+            }))
+          }
+        }
+      };
+    })
+  };
+}
+
+/** The cache with current shipped corrections, even before startup refresh. */
 export async function loadSpotlightCache(): Promise<SpotlightCache | null> {
-  return loadItem<SpotlightCache | null>(StorageKey.SPOTLIGHT_SERVERS, null);
+  const cache = await loadItem<SpotlightCache | null>(StorageKey.SPOTLIGHT_SERVERS, null);
+  return cache ? applySourceOverrides(cache) : null;
 }
 
 /**
@@ -94,7 +121,9 @@ async function doRefresh(): Promise<SpotlightCache> {
 
   // Keep the previous good record for entries that failed this time, so a
   // transient registry outage doesn't empty the tab until the next refresh.
-  const previous = await loadSpotlightCache();
+  // Keep fallback records raw too, so removing a shipped correction can take
+  // effect immediately without waiting for a successful registry refresh.
+  const previous = await loadItem<SpotlightCache | null>(StorageKey.SPOTLIGHT_SERVERS, null);
   if (previous) {
     for (const entry of cache.entries) {
       if (!entry.result) {
@@ -109,5 +138,5 @@ async function doRefresh(): Promise<SpotlightCache> {
   await saveItem(StorageKey.SPOTLIGHT_SERVERS, cache);
   const resolved = cache.entries.filter(e => e.result).length;
   log.info(`Spotlight refresh complete: ${resolved}/${cache.entries.length} entries resolved`);
-  return cache;
+  return applySourceOverrides(cache);
 }

--- a/src/shared/config/spotlightServers.ts
+++ b/src/shared/config/spotlightServers.ts
@@ -30,6 +30,8 @@ export interface SpotlightSource {
 export const SPOTLIGHT_SERVERS: (string | SpotlightSource)[] = [
   // Web search + page fetch (offers both a local npm package and a remote endpoint)
   'https://registry.modelcontextprotocol.io/?q=ai.keenable%2Fweb-search',
+  // Web search + page fetch (remote)
+  'https://registry.modelcontextprotocol.io/v0.1/servers/ai.parallel%2Fsearch-mcp/versions',
   'https://registry.modelcontextprotocol.io/v0.1/servers/io.github.mario-andreschak%2Fmcp-abap-adt/versions',
   {
     url: 'https://registry.modelcontextprotocol.io/v0.1/servers/io.github.microsoft%2Fplaywright-mcp/versions',

--- a/src/shared/config/spotlightServers.ts
+++ b/src/shared/config/spotlightServers.ts
@@ -1,8 +1,8 @@
 /**
  * Curated MCP servers shown in the ServerModal's "Spotlight" tab.
  *
- * Each entry is either a bare registry URL or a { url, env } object. The URL
- * points into the official MCP Registry, in one of three forms:
+ * Each entry is either a bare registry URL or a SpotlightSource with curated
+ * defaults. The URL points into the official MCP Registry, in one of three forms:
  *  - exact version:
  *    https://registry.modelcontextprotocol.io/v0.1/servers/<url-encoded name>/versions/<version>
  *  - version-less (versions list; resolved to the latest available version):
@@ -25,13 +25,24 @@ export interface SpotlightSource {
    * repo. Secrets must keep going through the existing isSecret env flow.
    */
   env?: Record<string, string>;
+  /**
+   * Exact remote URL corrections for this source only. Applied to fresh and
+   * cached records without changing their transport or declared headers.
+   */
+  remoteUrlOverrides?: Record<string, string>;
 }
 
 export const SPOTLIGHT_SERVERS: (string | SpotlightSource)[] = [
   // Web search + page fetch (offers both a local npm package and a remote endpoint)
   'https://registry.modelcontextprotocol.io/?q=ai.keenable%2Fweb-search',
   // Web search + page fetch (remote)
-  'https://registry.modelcontextprotocol.io/v0.1/servers/ai.parallel%2Fsearch-mcp/versions',
+  {
+    url: 'https://registry.modelcontextprotocol.io/v0.1/servers/ai.parallel%2Fsearch-mcp/versions',
+    // The registry still lists an endpoint that rejects anonymous requests.
+    remoteUrlOverrides: {
+      'https://search-mcp.parallel.ai/mcp': 'https://search.parallel.ai/mcp'
+    }
+  },
   'https://registry.modelcontextprotocol.io/v0.1/servers/io.github.mario-andreschak%2Fmcp-abap-adt/versions',
   {
     url: 'https://registry.modelcontextprotocol.io/v0.1/servers/io.github.microsoft%2Fplaywright-mcp/versions',


### PR DESCRIPTION
FLUJO's Spotlight gives users a short curated list of MCP servers without requiring a Marketplace search. Parallel Search MCP has an active registry entry with a remote option, so it fits that existing discovery path without adding another integration layer.

## What changed

- Added the version-less official MCP Registry reference for Parallel Search MCP to the Spotlight server list.
- Kept endpoint resolution, installation, and trust handling in FLUJO's existing registry flow.

## Validation

- `npm test -- --runInBand __tests__/mcp/registryUtils.test.ts` (46 tests passed)
- `npm run build`
- Verified the live registry record resolves as an active Streamable HTTP remote without required headers

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.
