### PR TITLE
Retry transient ECONNRESET / "Invalid response body" errors in OpenAI-compatible adapter

### DIFF
--- a/__tests__/model/transientRetry.test.ts
+++ b/__tests__/model/transientRetry.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for src/backend/utils/transientRetry.ts
+ *
+ * Uses jest.useFakeTimers() so back-off delays do not slow down the test suite.
+ * All tests are fully self-contained with no network calls.
+ */
+
+// Suppress logger output during tests.
+jest.mock('@/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import { isTransientTransportError, withTransientRetry } from '@/backend/utils/transientRetry';
+
+// ---------------------------------------------------------------------------
+// isTransientTransportError
+// ---------------------------------------------------------------------------
+
+describe('isTransientTransportError', () => {
+  describe('returns true for known transient transport error messages', () => {
+    it.each([
+      ['ECONNRESET', 'read ECONNRESET'],
+      [
+        'Invalid response body',
+        'Invalid response body while trying to fetch https://openrouter.ai/api/v1/chat/completions: read ECONNRESET',
+      ],
+      ['socket hang up', 'socket hang up'],
+      ['premature close', 'premature close'],
+      ['ETIMEDOUT (upper-case)', 'connect ETIMEDOUT 1.2.3.4:443'],
+      ['etimedout (lower-case)', 'etimedout'],
+    ])('%s', (_label, message) => {
+      expect(isTransientTransportError(new Error(message))).toBe(true);
+    });
+  });
+
+  describe('returns false for non-transient errors', () => {
+    it('returns false for AbortError (error.name === "AbortError")', () => {
+      const err = new Error('The operation was aborted.');
+      err.name = 'AbortError';
+      expect(isTransientTransportError(err)).toBe(false);
+    });
+
+    it('returns false for AuthenticationError messages', () => {
+      expect(
+        isTransientTransportError(new Error('401 Unauthorized: Invalid API key.'))
+      ).toBe(false);
+    });
+
+    it('returns false for plain TypeError with a non-transient message', () => {
+      expect(
+        isTransientTransportError(
+          new TypeError('Cannot read properties of undefined (reading "choices")')
+        )
+      ).toBe(false);
+    });
+
+    it('returns false for non-Error values', () => {
+      expect(isTransientTransportError('econnreset')).toBe(false);
+      expect(isTransientTransportError(null)).toBe(false);
+      expect(isTransientTransportError(undefined)).toBe(false);
+      expect(isTransientTransportError(42)).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withTransientRetry
+// ---------------------------------------------------------------------------
+
+describe('withTransientRetry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resolves immediately when fn succeeds on the first attempt', async () => {
+    const fn = jest.fn().mockResolvedValue('result');
+    const result = await withTransientRetry(fn);
+    expect(result).toBe('result');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries and succeeds when fn fails once with a transient error', async () => {
+    const transientErr = new Error('read ECONNRESET');
+    const fn = jest.fn()
+      .mockRejectedValueOnce(transientErr)
+      .mockResolvedValueOnce('ok');
+
+    const resultPromise = withTransientRetry(fn, { baseDelayMs: 500 });
+    // Advance fake timers so the back-off delay resolves and fn is retried.
+    await jest.runAllTimersAsync();
+
+    expect(await resultPromise).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-throws the last error after all attempts are exhausted', async () => {
+    const transientErr = new Error('socket hang up');
+    const fn = jest.fn().mockRejectedValue(transientErr);
+
+    const resultPromise = withTransientRetry(fn, { maxAttempts: 3, baseDelayMs: 100 });
+    await jest.runAllTimersAsync();
+
+    await expect(resultPromise).rejects.toThrow('socket hang up');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT retry when the error is non-transient', async () => {
+    const nonTransientErr = new Error('401 Unauthorized: Invalid API key.');
+    const fn = jest.fn().mockRejectedValue(nonTransientErr);
+
+    await expect(withTransientRetry(fn)).rejects.toThrow('401 Unauthorized');
+    // fn must have been called exactly once — no retry.
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT retry when the AbortSignal is already aborted before any attempt', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const fn = jest.fn().mockResolvedValue('ok');
+    await expect(
+      withTransientRetry(fn, { signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    // fn must not have been called at all.
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/src/backend/services/model/adapters/openaiAdapter.ts
+++ b/src/backend/services/model/adapters/openaiAdapter.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 import { createLogger } from '@/utils/logger';
 import { createOpenAIClient, getProviderDefaultHeaders } from '../openaiClient';
 import { CompletionAdapter, CompletionInput, CompletionResult } from './types';
+import { withTransientRetry } from '@/backend/utils/transientRetry';
 
 const log = createLogger('backend/services/model/adapters/openaiAdapter');
 
@@ -10,6 +11,11 @@ const log = createLogger('backend/services/model/adapters/openaiAdapter');
  * OpenAI, OpenRouter, X.ai, Ollama, and the "OpenAI Format" variants of Gemini
  * and Anthropic. Uses the shared hardened client (keep-alive disabled) to avoid
  * the intermittent "Premature close" transport bug.
+ *
+ * A thin `withTransientRetry` wrapper re-issues the HTTP request (up to 3
+ * total attempts, 500 ms → 1 s back-off) when the provider resets the
+ * connection while reading the response body — the ECONNRESET / "Invalid
+ * response body" window that the OpenAI SDK's own `maxRetries` cannot cover.
  */
 export class OpenAiAdapter implements CompletionAdapter {
   async createCompletion({
@@ -50,9 +56,13 @@ export class OpenAiAdapter implements CompletionAdapter {
 
     // No `stream: true`, so the SDK resolves to a ChatCompletion. The abort
     // signal (Stop button) cancels the in-flight HTTP request.
-    const completion = (await openai.chat.completions.create(
-      requestParams,
-      signal ? { signal } : undefined
+    // withTransientRetry re-issues the entire request when a transient
+    // transport error (ECONNRESET, "Invalid response body", …) is detected
+    // while reading the response body — after the provider has already sent
+    // HTTP 200 OK, where the SDK's own maxRetries is no longer in the path.
+    const completion = (await withTransientRetry(
+      () => openai.chat.completions.create(requestParams, signal ? { signal } : undefined),
+      { signal }
     )) as OpenAI.Chat.Completions.ChatCompletion;
     return { completion };
   }

--- a/src/backend/utils/transientRetry.ts
+++ b/src/backend/utils/transientRetry.ts
@@ -1,0 +1,83 @@
+import { createLogger } from '@/utils/logger';
+
+const log = createLogger('backend/utils/transientRetry');
+
+const TRANSIENT_KEYWORDS = [
+  'econnreset',
+  'invalid response body',
+  'socket hang up',
+  'premature close',
+  'etimedout',
+] as const;
+
+/**
+ * Returns true when the given error looks like a transient transport-layer
+ * failure that is worth retrying (ECONNRESET, stream truncation, keep-alive
+ * drops, …).  AbortErrors are explicitly excluded: those originate from a
+ * deliberate user cancel and must never be retried.
+ */
+export function isTransientTransportError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  // Never retry a user-initiated abort.
+  if (error.name === 'AbortError') return false;
+  const msg = error.message.toLowerCase();
+  return TRANSIENT_KEYWORDS.some((kw) => msg.includes(kw));
+}
+
+export interface TransientRetryOptions {
+  /** Total attempts (initial + retries). Default 3. */
+  maxAttempts?: number;
+  /** Base delay in ms; doubles each retry. Default 500. */
+  baseDelayMs?: number;
+  /** When provided, an already-aborted signal skips all retries. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Wraps an async function `fn` in a retry loop that re-issues the call when
+ * {@link isTransientTransportError} identifies a transient transport failure.
+ *
+ * - Maximum `maxAttempts` total attempts (default 3: initial + 2 retries).
+ * - Exponential back-off: `baseDelayMs * 2^(attempt-1)` (500 ms → 1 s).
+ * - The caller's `AbortSignal` is respected both at the start of each attempt
+ *   and during the back-off delay (pressing "Stop" cancels immediately).
+ * - Non-transient errors (4xx/5xx, AuthenticationError, …) are re-thrown
+ *   immediately without any retry.
+ */
+export async function withTransientRetry<T>(
+  fn: () => Promise<T>,
+  opts: TransientRetryOptions = {}
+): Promise<T> {
+  const { maxAttempts = 3, baseDelayMs = 500, signal } = opts;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (signal?.aborted) {
+      throw lastError ?? new DOMException('Aborted', 'AbortError');
+    }
+    try {
+      return await fn();
+    } catch (err) {
+      if (!isTransientTransportError(err) || attempt >= maxAttempts) {
+        throw err;
+      }
+      lastError = err;
+      const delayMs = baseDelayMs * Math.pow(2, attempt - 1);
+      log.warn(
+        `Transient transport error on attempt ${attempt}/${maxAttempts}; retrying in ${delayMs} ms`,
+        { message: err instanceof Error ? err.message : String(err) }
+      );
+      await new Promise<void>((resolve, reject) => {
+        const t = setTimeout(resolve, delayMs);
+        signal?.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(t);
+            reject(lastError);
+          },
+          { once: true }
+        );
+      });
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Summary

Wraps the `openai.chat.completions.create(...)` call inside `OpenAiAdapter` in a thin retry loop (`withTransientRetry`) that re-issues the entire HTTP request when a transient transport error (ECONNRESET, "Invalid response body", socket hang up, premature close, ETIMEDOUT) is detected. Maximum 3 total attempts with exponential back-off (500 ms → 1 s). Aborting mid-retry propagates cleanly via `AbortSignal`.

## Files touched

- `src/backend/utils/transientRetry.ts` *(new)* — `isTransientTransportError` + `withTransientRetry` helpers
- `src/backend/services/model/adapters/openaiAdapter.ts` — wraps `chat.completions.create` with `withTransientRetry`
- `__tests__/model/transientRetry.test.ts` *(new)* — full unit-test suite (fake timers, no network)

## How to verify

1. **Unit tests**: `npm test -- --runInBand __tests__/model/transientRetry.test.ts` — all tests pass.
2. **Static check**: open `src/backend/utils/transientRetry.ts` and confirm `TRANSIENT_KEYWORDS` includes `econnreset` and `invalid response body`; open `openaiAdapter.ts` and confirm `withTransientRetry` wraps `chat.completions.create`.
3. **Smoke test**: configure an OpenRouter model, trigger a chat — normal calls are unaffected. A one-shot ECONNRESET injected into the adapter succeeds on the second attempt without surfacing an error to the user.

Closes #227