### PR TITLE
Fix JSON schema `required` field validation for Google AI Studio / Gemini via OpenRouter

### DIFF
--- a/__tests__/flow/toolHandlerSanitizeSchema.test.ts
+++ b/__tests__/flow/toolHandlerSanitizeSchema.test.ts
@@ -1,0 +1,122 @@
+import { ToolHandler } from '@/backend/execution/flow/handlers/ToolHandler';
+
+describe('ToolHandler.sanitizeSchema — required field filtering', () => {
+  it('preserves required when all keys are in properties', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' }, age: { type: 'number' } },
+      required: ['name', 'age'],
+    };
+    const result = ToolHandler.sanitizeSchema(schema);
+    expect(result.required).toEqual(['name', 'age']);
+  });
+
+  it('drops unknown key from required', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name', 'nonexistent'],
+    };
+    const result = ToolHandler.sanitizeSchema(schema);
+    expect(result.required).toEqual(['name']);
+  });
+
+  it('removes required entirely when all keys are undefined', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['ghost'],
+    };
+    const result = ToolHandler.sanitizeSchema(schema);
+    expect(result.required).toBeUndefined();
+  });
+
+  it('removes required when properties is absent', () => {
+    const schema = {
+      type: 'object',
+      required: ['field1'],
+    };
+    const result = ToolHandler.sanitizeSchema(schema);
+    expect(result.required).toBeUndefined();
+  });
+
+  it('fixes items.required referencing undefined property (issue #228 exact repro)', () => {
+    // Mirrors: issue_fields param of issue_write tool
+    const schema = {
+      type: 'object',
+      properties: {
+        issue_fields: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              field_name: { type: 'string' },
+              value: { type: 'string' },
+            },
+            // 'delete' is NOT in properties — Google AI Studio rejects this
+            required: ['field_name', 'delete'],
+          },
+        },
+      },
+    };
+    const result = ToolHandler.sanitizeSchema(schema);
+    expect(result.properties.issue_fields.items.required).toEqual(['field_name']);
+  });
+
+  it('removes items.required when it becomes empty', () => {
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { x: { type: 'number' } },
+        required: ['nonexistent'],
+      },
+    };
+    const result = ToolHandler.sanitizeSchema(schema);
+    expect(result.items.required).toBeUndefined();
+  });
+
+  it('fixes required inside nested properties recursively', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        outer: {
+          type: 'object',
+          properties: { inner: { type: 'string' } },
+          required: ['inner', 'ghost'],
+        },
+      },
+    };
+    const result = ToolHandler.sanitizeSchema(schema);
+    expect(result.properties.outer.required).toEqual(['inner']);
+  });
+
+  it('still strips unsupported format alongside required filtering', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        url: { type: 'string', format: 'uri' },
+        name: { type: 'string' },
+      },
+      required: ['url', 'name', 'missing'],
+    };
+    const result = ToolHandler.sanitizeSchema(schema);
+    expect(result.properties.url.format).toBeUndefined();
+    expect(result.properties.url.description).toContain('format: uri');
+    expect(result.required).toEqual(['url', 'name']);
+  });
+
+  it('sanitizes schemas inside oneOf/anyOf/allOf', () => {
+    const schema = {
+      oneOf: [
+        {
+          type: 'object',
+          properties: { a: { type: 'string' } },
+          required: ['a', 'missing'],
+        },
+      ],
+    };
+    const result = ToolHandler.sanitizeSchema(schema);
+    expect(result.oneOf[0].required).toEqual(['a']);
+  });
+});

--- a/src/backend/execution/flow/handlers/ToolHandler.ts
+++ b/src/backend/execution/flow/handlers/ToolHandler.ts
@@ -18,6 +18,9 @@ export class ToolHandler {
   /**
    * Sanitizes a JSON Schema to ensure compatibility with all LLM providers
    * Specifically removes unsupported 'format' fields from string properties
+   * and filters 'required' arrays to only reference keys defined in 'properties'
+   * (Google AI Studio / Gemini via OpenRouter rejects schemas where required
+   * contains keys not present in properties).
    */
   static sanitizeSchema(schema: any): any {
     if (!schema || typeof schema !== 'object') return schema;
@@ -43,6 +46,25 @@ export class ToolHandler {
       Object.keys(result.properties).forEach(key => {
         result.properties[key] = ToolHandler.sanitizeSchema(result.properties[key]);
       });
+    }
+
+    // Google AI Studio (and other strict providers) reject schemas where `required`
+    // references property names not defined in `properties`. Filter required so it
+    // only contains keys that are actually declared. Remove `required` entirely when
+    // it would become empty or when there are no `properties` at all.
+    if (Array.isArray(result.required)) {
+      if (result.properties && typeof result.properties === 'object') {
+        const definedKeys = new Set(Object.keys(result.properties));
+        result.required = (result.required as unknown[]).filter(
+          (k): k is string => typeof k === 'string' && definedKeys.has(k)
+        );
+        if (result.required.length === 0) {
+          delete result.required;
+        }
+      } else {
+        // No properties declared → `required` can only be invalid; drop it.
+        delete result.required;
+      }
     }
     
     // Process array items


### PR DESCRIPTION
## Summary

Google AI Studio enforces a strict JSON Schema rule: every key in a schema's `required` array must also appear in `properties`. MCP server tool schemas often violate this (e.g. `items.required` references keys not in `items.properties`), causing HTTP 400 from Google AI Studio when routing through OpenRouter.

Adds a `required`-filtering step inside the existing recursive `ToolHandler.sanitizeSchema()`: after processing `properties`, keys in `required` that are not declared in `properties` are dropped; if `required` becomes empty (or `properties` is absent), `required` is deleted entirely. The fix recurses into nested objects, `items`, and `oneOf`/`anyOf`/`allOf` schemas automatically.

## Files touched

- `src/backend/execution/flow/handlers/ToolHandler.ts` — new `required` filtering block inside `sanitizeSchema`
- `__tests__/flow/toolHandlerSanitizeSchema.test.ts` *(new)* — 8 regression tests (pure static function, no mocks needed)

## How to verify

1. **Unit tests**: `npm test -- --runInBand __tests__/flow/toolHandlerSanitizeSchema.test.ts` — all 8 tests pass.
2. **Static check**: open `ToolHandler.ts`, locate `sanitizeSchema`, confirm the `if (Array.isArray(result.required))` block appears after the `if (result.properties)` block and before `if (result.items)`.
3. **Integration**: configure a flow with OpenRouter → Gemini and an MCP server whose tool schemas have `required` referencing undefined property names — requests succeed (no 400).

Closes #228