### PR TITLE
Anthropic Native adapter — omit `temperature` for models that have deprecated it

### DIFF
--- a/__tests__/backend/services/model/adapters/anthropicTemperature.test.ts
+++ b/__tests__/backend/services/model/adapters/anthropicTemperature.test.ts
@@ -1,0 +1,82 @@
+import { AnthropicAdapter, anthropicModelSupportsTemperature }
+  from '@/backend/services/model/adapters/anthropicAdapter';
+import { Model } from '@/shared/types/model';
+import OpenAI from 'openai';
+
+jest.mock('@/utils/logger', () => {
+  const log = { verbose: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  return { createLogger: () => log };
+});
+const mockLog = (jest.requireMock('@/utils/logger') as any).createLogger();
+
+jest.mock('@anthropic-ai/sdk', () => {
+  const create = jest.fn();
+  const BadRequestError = class extends Error {
+    status = 400;
+    constructor(msg: string) { super(msg); }
+  };
+  const Anthropic = jest.fn().mockImplementation(() => ({ messages: { create } }));
+  (Anthropic as any).BadRequestError = BadRequestError;
+  return { __esModule: true, default: Anthropic, __create: create };
+});
+
+const anthropicCreate = (jest.requireMock('@anthropic-ai/sdk') as any).__create;
+
+const GOOD_RESP = {
+  id: 'a', model: 'test', content: [{ type: 'text', text: 'hi' }],
+  stop_reason: 'end_turn', usage: { input_tokens: 1, output_tokens: 1 },
+};
+const BASE_MODEL: Model = { id: 'm', name: 'claude-3-5-sonnet-20241022', ApiKey: 'k' } as Model;
+const NO_TEMP_MODEL: Model = { ...BASE_MODEL, name: 'claude-opus-4-7-20260501' };
+const MSGS: OpenAI.ChatCompletionMessageParam[] = [{ role: 'user', content: 'hi' }];
+
+describe('anthropicModelSupportsTemperature', () => {
+  test('returns false for known no-temperature models', () => {
+    expect(anthropicModelSupportsTemperature('claude-opus-4-7')).toBe(false);
+    expect(anthropicModelSupportsTemperature('claude-opus-4-7-20260401')).toBe(false);
+    expect(anthropicModelSupportsTemperature('claude-opus-4-8')).toBe(false);
+    expect(anthropicModelSupportsTemperature('claude-fable-5')).toBe(false);
+    expect(anthropicModelSupportsTemperature('claude-sonnet-5')).toBe(false);
+  });
+  test('returns true for standard models', () => {
+    expect(anthropicModelSupportsTemperature('claude-3-5-sonnet-20241022')).toBe(true);
+    expect(anthropicModelSupportsTemperature('claude-opus-4-6')).toBe(true);
+  });
+});
+
+describe('AnthropicAdapter temperature behaviour', () => {
+  beforeEach(() => { jest.clearAllMocks(); anthropicCreate.mockResolvedValue(GOOD_RESP); });
+
+  test('includes temperature for standard models', async () => {
+    await new AnthropicAdapter().createCompletion({
+      model: BASE_MODEL, apiKey: 'k', messages: MSGS, temperature: 0.7,
+    });
+    expect(anthropicCreate.mock.calls[0][0]).toHaveProperty('temperature', 0.7);
+  });
+
+  test('omits temperature for known no-temp models', async () => {
+    await new AnthropicAdapter().createCompletion({
+      model: NO_TEMP_MODEL, apiKey: 'k', messages: MSGS, temperature: 0.7,
+    });
+    expect(anthropicCreate.mock.calls[0][0]).not.toHaveProperty('temperature');
+  });
+
+  test('retries without temperature when Anthropic returns 400 "deprecated" error', async () => {
+    const Anthropic = jest.requireMock('@anthropic-ai/sdk').default;
+    const err = new Anthropic.BadRequestError('`temperature` is deprecated for this model.');
+    anthropicCreate.mockRejectedValueOnce(err).mockResolvedValueOnce(GOOD_RESP);
+
+    // Use a standard model (not on denylist) so temperature IS included on first call.
+    const result = await new AnthropicAdapter().createCompletion({
+      model: BASE_MODEL, apiKey: 'k', messages: MSGS, temperature: 0.7,
+    });
+
+    expect(anthropicCreate).toHaveBeenCalledTimes(2);
+    // First call included temperature
+    expect(anthropicCreate.mock.calls[0][0]).toHaveProperty('temperature');
+    // Second call omitted it
+    expect(anthropicCreate.mock.calls[1][0]).not.toHaveProperty('temperature');
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    expect(result.completion).toBeDefined();
+  });
+});

--- a/src/backend/services/model/adapters/anthropicAdapter.ts
+++ b/src/backend/services/model/adapters/anthropicAdapter.ts
@@ -14,6 +14,37 @@ const log = createLogger('backend/services/model/adapters/anthropicAdapter');
 const DEFAULT_MAX_TOKENS = 8192;
 
 /**
+ * Static denylist of model-name substrings that no longer accept the
+ * `temperature` sampling parameter (Anthropic deprecated it for adaptive-
+ * thinking models starting with claude-opus-4-7).
+ *
+ * Rules:
+ * - Match is case-insensitive substring; we use lowercase model names.
+ * - Prefer false-negatives (include temperature) over false-positives (break
+ *   the call) for unknown models: an unsupported temperature produces a 400
+ *   that the retry path catches; a missing temperature on a model that wants it
+ *   would silently change behaviour.
+ */
+const TEMPERATURE_DEPRECATED_SUBSTRINGS = [
+  'claude-opus-4-7',
+  'claude-opus-4-8',
+  'claude-opus-4-9',
+  'claude-fable-4',
+  'claude-fable-5',
+  'claude-sonnet-5',
+  'claude-haiku-5',
+] as const;
+
+/**
+ * Returns true when the Anthropic model is expected to accept the `temperature`
+ * parameter; false for models that reject it with a 400.
+ */
+export function anthropicModelSupportsTemperature(modelName: string): boolean {
+  const lower = modelName.toLowerCase();
+  return !TEMPERATURE_DEPRECATED_SUBSTRINGS.some(s => lower.includes(s));
+}
+
+/**
  * Convert OpenAI-format messages into Anthropic's shape:
  *   - system messages are hoisted into the top-level `system` string
  *   - assistant tool_calls become `tool_use` content blocks
@@ -214,10 +245,11 @@ export class AnthropicAdapter implements CompletionAdapter {
     const { system, messages: anthropicMessages } = toAnthropicMessages(messages);
     const anthropicTools = toAnthropicTools(tools);
 
+    const includeTemperature = anthropicModelSupportsTemperature(model.name);
     const params: Anthropic.MessageCreateParamsNonStreaming = {
       model: model.name,
       max_tokens: maxTokens ?? DEFAULT_MAX_TOKENS,
-      temperature,
+      ...(includeTemperature ? { temperature } : {}),
       messages: anthropicMessages,
       ...(system ? { system } : {}),
       ...(anthropicTools ? { tools: anthropicTools } : {}),
@@ -230,7 +262,30 @@ export class AnthropicAdapter implements CompletionAdapter {
     });
 
     // The abort signal (Stop button) cancels the in-flight HTTP request.
-    const resp = await client.messages.create(params, signal ? { signal } : undefined);
+    let resp: Anthropic.Message;
+    try {
+      resp = await client.messages.create(params, signal ? { signal } : undefined);
+    } catch (err) {
+      // Some models (e.g. claude-opus-4-7+) reject `temperature` with a 400.
+      // When not yet covered by the static denylist, auto-retry without it.
+      if (
+        err instanceof Anthropic.BadRequestError &&
+        err.message.includes('temperature') &&
+        err.message.toLowerCase().includes('deprecated') &&
+        'temperature' in params
+      ) {
+        log.warn(
+          'Anthropic API rejected temperature for model; retrying without it. ' +
+            'Consider adding this model to TEMPERATURE_DEPRECATED_SUBSTRINGS.',
+          { model: model.name }
+        );
+        const paramsWithoutTemp = { ...params };
+        delete (paramsWithoutTemp as Partial<typeof paramsWithoutTemp>).temperature;
+        resp = await client.messages.create(paramsWithoutTemp, signal ? { signal } : undefined);
+      } else {
+        throw err;
+      }
+    }
     return { completion: toChatCompletion(model.name, resp) };
   }
 }


### PR DESCRIPTION
## Summary

Newer Anthropic "adaptive-thinking" models (claude-opus-4-7 and later) return HTTP 400 `temperature is deprecated for this model` when `temperature` is included in the API request. 

This PR adds two defences in `anthropicAdapter.ts`:

1. **Static denylist** (`TEMPERATURE_DEPRECATED_SUBSTRINGS`): known model name substrings for which `temperature` is omitted upfront via `anthropicModelSupportsTemperature()`.
2. **Catch-and-retry**: if a model not yet on the denylist returns a 400 mentioning "temperature" + "deprecated", the adapter automatically retries the request without `temperature` and emits a `warn` log recommending the model be added to the denylist.

## Files touched

- `src/backend/services/model/adapters/anthropicAdapter.ts` — `TEMPERATURE_DEPRECATED_SUBSTRINGS`, `anthropicModelSupportsTemperature`, conditional `temperature` spread, catch-and-retry block
- `__tests__/backend/services/model/adapters/anthropicTemperature.test.ts` *(new)* — unit tests for the helper function and all three call paths (standard, no-temp, retry)

## How to verify

1. **Unit tests**: `npm test -- --runInBand __tests__/backend/services/model/adapters/anthropicTemperature.test.ts` — all tests pass.
2. **Static check**: confirm `TEMPERATURE_DEPRECATED_SUBSTRINGS` in `anthropicAdapter.ts` contains `claude-opus-4-7`; confirm `params` construction uses `...(includeTemperature ? { temperature } : {})`.
3. **Live test**: configure FLUJO with provider "Anthropic (Native)" and model `claude-opus-4-7-*`, send a chat message — no 400 error.

Closes #229