### PR TITLE
Waves Canvas — Zoom, Hover Visibility, Auto-scaling, and Layout Fixes

### DIFF
--- a/src/frontend/components/Waves/WaveCanvas.tsx
+++ b/src/frontend/components/Waves/WaveCanvas.tsx
@@ -23,6 +23,7 @@ import {
   WAVE_WINDOWS,
   WAVE_WINDOW_KEYS,
   timelineTicks,
+  autoWindowForWave,
   type WaveWindowKey,
 } from './waveTimeline';
 
@@ -67,11 +68,11 @@ interface WaveCanvasProps {
  * "now"; timeline roots are placed by time-to-next-run (right = further out) and a
  * recurring schedule expands into one card per upcoming run in the window. The
  * chain is revealed lazily: hover a card to drop its next level below it and keep
- * following to arbitrary depth. The canvas never hijacks page scroll.
+ * following to arbitrary depth.
  */
 function WaveCanvasInner({ wave, height = 460 }: WaveCanvasProps) {
   const [now, setNow] = useState(() => Date.now());
-  const [windowKey, setWindowKey] = useState<WaveWindowKey>(DEFAULT_WAVE_WINDOW);
+  const [windowKey, setWindowKey] = useState<WaveWindowKey>(() => autoWindowForWave(wave, Date.now()));
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
   // Click-to-pin (#209): a pinned chain holds open (ignoring hover-out) until the
   // canvas background is clicked. The pin always wins over transient hover.
@@ -179,12 +180,11 @@ function WaveCanvasInner({ wave, height = 460 }: WaveCanvasProps) {
         nodesDraggable={false}
         nodesConnectable={false}
         elementsSelectable={false}
-        // Never swallow the page's wheel scroll (#144).
-        zoomOnScroll={false}
-        zoomOnPinch={false}
-        zoomOnDoubleClick={false}
+        zoomOnScroll={true}
+        zoomOnPinch={true}
+        zoomOnDoubleClick={true}
         panOnScroll={false}
-        preventScrolling={false}
+        preventScrolling={true}
         panOnDrag
         onNodeMouseEnter={(_e, node) => {
           if (clearTimer.current) clearTimeout(clearTimer.current);
@@ -197,7 +197,7 @@ function WaveCanvasInner({ wave, height = 460 }: WaveCanvasProps) {
         onNodeMouseLeave={() => {
           if (clearTimer.current) clearTimeout(clearTimer.current);
           // Grace period so the mouse can travel to a freshly-revealed child.
-          clearTimer.current = setTimeout(() => setHoveredKey(null), 260);
+          clearTimer.current = setTimeout(() => setHoveredKey(null), 800);
         }}
         onNodeClick={(_e, node) => {
           if (node.type === 'clock' || node.type === 'tick') return;

--- a/src/frontend/components/Waves/waveGraph.ts
+++ b/src/frontend/components/Waves/waveGraph.ts
@@ -28,13 +28,13 @@ import { enumerateOccurrences, timelineFraction } from './waveTimeline';
 export const CLOCK_X = 16;
 export const BASE_Y = 24;
 /** Vertical distance between chain levels. */
-export const LANE_H = 150;
+export const LANE_H = 220;
 /** Left edge of the timeline band (right of the clock). */
 export const TIMELINE_X0 = 160;
 /** Width of the timeline band the window is mapped across. */
 export const TIMELINE_W = 620;
 /** Horizontal spacing between sibling cards in an expanded level. */
-export const CHILD_SPACING = 250;
+export const CHILD_SPACING = 320;
 
 /* --------------------------------------------------------------------- */
 /* Public shapes                                                          */

--- a/src/frontend/components/Waves/waveTimeline.ts
+++ b/src/frontend/components/Waves/waveTimeline.ts
@@ -11,6 +11,7 @@
  * scheduler) and is safe to bundle in the browser.
  */
 
+import type { Wave } from '@/shared/types/waves/waves';
 import { Cron } from 'croner';
 
 /** Selectable look-ahead windows for the timeline. */
@@ -157,4 +158,30 @@ export function timelineTicks(now: number, windowMs: number, step?: number): Tim
     });
   }
   return out;
+}
+
+/**
+ * Choose the most readable WaveWindowKey for a given wave by estimating the
+ * shortest cron interval among its timeline-mode roots. Targets showing roughly
+ * 4–6 occurrences (interval × 6). Falls back to DEFAULT_WAVE_WINDOW when no
+ * cron pattern is present.
+ */
+export function autoWindowForWave(wave: Wave, now: number): WaveWindowKey {
+  let minIntervalMs = Infinity;
+  for (const node of wave.nodes) {
+    if (node.timing.mode !== 'timeline') continue;
+    const cron = (node.timing as { cron?: string }).cron;
+    if (!cron) continue;
+    // Sample 3 occurrences within a 1-day window to derive the interval.
+    const occs = enumerateOccurrences(cron, now, 24 * 60 * 60 * 1000, 3);
+    if (occs.length >= 2) {
+      const interval = occs[1] - occs[0];
+      if (interval < minIntervalMs) minIntervalMs = interval;
+    }
+  }
+  if (!Number.isFinite(minIntervalMs)) return DEFAULT_WAVE_WINDOW;
+  const targetWindow = minIntervalMs * 6;
+  if (targetWindow <= WAVE_WINDOWS['1h']) return '1h';
+  if (targetWindow <= WAVE_WINDOWS['6h']) return '6h';
+  return '1d';
 }


### PR DESCRIPTION
## Summary

Fixes four distinct UX issues on the `/waves` canvas:

1. **Mousewheel zoom** (`WaveCanvas.tsx`): re-enables `zoomOnScroll`, `zoomOnPinch`, `zoomOnDoubleClick` and sets `preventScrolling={true}` so the browser wheel event zooms the canvas instead of scrolling the page.
2. **Hover grace period** (`WaveCanvas.tsx`): increases the `onNodeMouseLeave` setTimeout from 260 ms to 800 ms, giving the mouse enough time to travel from a root card to a revealed child card without the chain collapsing.
3. **Auto-scaling timeline window** (`waveTimeline.ts` + `WaveCanvas.tsx`): adds `autoWindowForWave()` that estimates the shortest cron interval among a wave's timeline-mode roots and picks an appropriate `WaveWindowKey` (1h / 6h / 1d); used as the `useState` initializer for `windowKey`.
4. **Layout overlap** (`waveGraph.ts`): increases `LANE_H` from 150 to 220 and `CHILD_SPACING` from 250 to 320, preventing horizontal card overlap and ensuring edge arrows are not hidden behind card bodies.

## Files touched

- `src/frontend/components/Waves/waveTimeline.ts` — new `autoWindowForWave` export + `import type { Wave }`
- `src/frontend/components/Waves/WaveCanvas.tsx` — zoom props, hover timeout, `useState` initializer
- `src/frontend/components/Waves/waveGraph.ts` — `LANE_H = 220`, `CHILD_SPACING = 320`

## How to verify

1. **Static check**: search `WaveCanvas.tsx` for `zoomOnScroll={true}`, `preventScrolling={true}`, `setTimeout` value `800`, and `autoWindowForWave` in `useState` initializer; search `waveGraph.ts` for `LANE_H = 220` and `CHILD_SPACING = 320`; search `waveTimeline.ts` for `export function autoWindowForWave`.
2. **Live test** (no automated tests for this purely visual change): navigate to `/waves`, open a recurring wave — canvas opens in the appropriate window for the cron interval; mousewheel zooms the canvas; slowly moving mouse from root to child card keeps the chain visible; expanded siblings do not overlap.

Closes #231