### PR TITLE
feat: dynamic Anthropic temperature capability detection + streaming temperature guard

### DIFF
--- a/__tests__/backend/services/model/adapters/anthropicTemperature.test.ts
+++ b/__tests__/backend/services/model/adapters/anthropicTemperature.test.ts
@@ -1,4 +1,4 @@
-import { AnthropicAdapter, anthropicModelSupportsTemperature }
+import { AnthropicAdapter, anthropicModelSupportsTemperature, clearModelCapabilityCache }
   from '@/backend/services/model/adapters/anthropicAdapter';
 import { Model } from '@/shared/types/model';
 import OpenAI from 'openai';
@@ -11,16 +11,23 @@ const mockLog = (jest.requireMock('@/utils/logger') as any).createLogger();
 
 jest.mock('@anthropic-ai/sdk', () => {
   const create = jest.fn();
+  const retrieve = jest.fn();
+  const stream = jest.fn();
   const BadRequestError = class extends Error {
     status = 400;
     constructor(msg: string) { super(msg); }
   };
-  const Anthropic = jest.fn().mockImplementation(() => ({ messages: { create } }));
+  const Anthropic = jest.fn().mockImplementation(() => ({
+    messages: { create, stream },
+    models: { retrieve },
+  }));
   (Anthropic as any).BadRequestError = BadRequestError;
-  return { __esModule: true, default: Anthropic, __create: create };
+  return { __esModule: true, default: Anthropic, __create: create, __retrieve: retrieve, __stream: stream };
 });
 
 const anthropicCreate = (jest.requireMock('@anthropic-ai/sdk') as any).__create;
+const anthropicRetrieve = (jest.requireMock('@anthropic-ai/sdk') as any).__retrieve;
+const anthropicStream = (jest.requireMock('@anthropic-ai/sdk') as any).__stream;
 
 const GOOD_RESP = {
   id: 'a', model: 'test', content: [{ type: 'text', text: 'hi' }],
@@ -30,22 +37,35 @@ const BASE_MODEL: Model = { id: 'm', name: 'claude-3-5-sonnet-20241022', ApiKey:
 const NO_TEMP_MODEL: Model = { ...BASE_MODEL, name: 'claude-opus-4-7-20260501' };
 const MSGS: OpenAI.ChatCompletionMessageParam[] = [{ role: 'user', content: 'hi' }];
 
+/** Create a minimal MockStream for the streaming tests. */
+function makeMockStream(resolveWith: typeof GOOD_RESP) {
+  return { finalMessage: jest.fn().mockResolvedValue(resolveWith) };
+}
+
 describe('anthropicModelSupportsTemperature', () => {
-  test('returns false for known no-temperature models', () => {
-    expect(anthropicModelSupportsTemperature('claude-opus-4-7')).toBe(false);
-    expect(anthropicModelSupportsTemperature('claude-opus-4-7-20260401')).toBe(false);
-    expect(anthropicModelSupportsTemperature('claude-opus-4-8')).toBe(false);
-    expect(anthropicModelSupportsTemperature('claude-fable-5')).toBe(false);
-    expect(anthropicModelSupportsTemperature('claude-sonnet-5')).toBe(false);
+  beforeEach(() => { jest.clearAllMocks(); clearModelCapabilityCache(); });
+
+  test('returns false for known no-temperature models', async () => {
+    expect(await anthropicModelSupportsTemperature('claude-opus-4-7', undefined)).toBe(false);
+    expect(await anthropicModelSupportsTemperature('claude-opus-4-7-20260401', undefined)).toBe(false);
+    expect(await anthropicModelSupportsTemperature('claude-opus-4-8', undefined)).toBe(false);
+    expect(await anthropicModelSupportsTemperature('claude-fable-5', undefined)).toBe(false);
+    expect(await anthropicModelSupportsTemperature('claude-sonnet-5', undefined)).toBe(false);
   });
-  test('returns true for standard models', () => {
-    expect(anthropicModelSupportsTemperature('claude-3-5-sonnet-20241022')).toBe(true);
-    expect(anthropicModelSupportsTemperature('claude-opus-4-6')).toBe(true);
+  test('returns true for standard models', async () => {
+    expect(await anthropicModelSupportsTemperature('claude-3-5-sonnet-20241022', undefined)).toBe(true);
+    expect(await anthropicModelSupportsTemperature('claude-opus-4-6', undefined)).toBe(true);
   });
 });
 
 describe('AnthropicAdapter temperature behaviour', () => {
-  beforeEach(() => { jest.clearAllMocks(); anthropicCreate.mockResolvedValue(GOOD_RESP); });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearModelCapabilityCache();
+    anthropicCreate.mockResolvedValue(GOOD_RESP);
+    // Return empty object so retrieve falls through to static denylist
+    anthropicRetrieve.mockResolvedValue({});
+  });
 
   test('includes temperature for standard models', async () => {
     await new AnthropicAdapter().createCompletion({
@@ -76,6 +96,107 @@ describe('AnthropicAdapter temperature behaviour', () => {
     expect(anthropicCreate.mock.calls[0][0]).toHaveProperty('temperature');
     // Second call omitted it
     expect(anthropicCreate.mock.calls[1][0]).not.toHaveProperty('temperature');
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    expect(result.completion).toBeDefined();
+  });
+});
+
+describe('dynamic capability detection', () => {
+  const ADAPTIVE_CAPS = {
+    capabilities: { thinking: { types: { adaptive: { supported: true } } } },
+  };
+  const NON_ADAPTIVE_CAPS = {
+    capabilities: { thinking: { types: { adaptive: { supported: false } } } },
+  };
+
+  beforeEach(() => { jest.clearAllMocks(); clearModelCapabilityCache(); });
+
+  test('returns false when API reports adaptive.supported = true', async () => {
+    anthropicRetrieve.mockResolvedValueOnce(ADAPTIVE_CAPS);
+    const result = await anthropicModelSupportsTemperature(
+      'claude-new-unknown-adaptive', new (jest.requireMock('@anthropic-ai/sdk').default)()
+    );
+    expect(result).toBe(false);
+    expect(anthropicRetrieve).toHaveBeenCalledWith('claude-new-unknown-adaptive');
+  });
+
+  test('returns true when API reports adaptive.supported = false', async () => {
+    anthropicRetrieve.mockResolvedValueOnce(NON_ADAPTIVE_CAPS);
+    const result = await anthropicModelSupportsTemperature(
+      'claude-3-future-model', new (jest.requireMock('@anthropic-ai/sdk').default)()
+    );
+    expect(result).toBe(true);
+  });
+
+  test('falls back to static denylist when API returns no capabilities', async () => {
+    anthropicRetrieve.mockResolvedValueOnce({});
+    // 'claude-opus-4-7' is on the static denylist → false
+    const r1 = await anthropicModelSupportsTemperature(
+      'claude-opus-4-7', new (jest.requireMock('@anthropic-ai/sdk').default)()
+    );
+    expect(r1).toBe(false);
+  });
+
+  test('falls back to static denylist when API throws', async () => {
+    anthropicRetrieve.mockRejectedValueOnce(new Error('network error'));
+    // standard model not on denylist → true
+    const r2 = await anthropicModelSupportsTemperature(
+      'claude-3-5-sonnet-20241022', new (jest.requireMock('@anthropic-ai/sdk').default)()
+    );
+    expect(r2).toBe(true);
+  });
+
+  test('caches API result — second call does not re-call retrieve', async () => {
+    anthropicRetrieve.mockResolvedValue(ADAPTIVE_CAPS);
+    const c = new (jest.requireMock('@anthropic-ai/sdk').default)();
+    await anthropicModelSupportsTemperature('claude-cached-model', c);
+    await anthropicModelSupportsTemperature('claude-cached-model', c);
+    expect(anthropicRetrieve).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AnthropicAdapter streaming temperature behaviour', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    anthropicStream.mockReturnValue(makeMockStream(GOOD_RESP));
+    if (typeof clearModelCapabilityCache === 'function') clearModelCapabilityCache();
+    anthropicRetrieve.mockResolvedValue({});
+  });
+
+  test('includes temperature for standard models', async () => {
+    await new AnthropicAdapter().createStreamCompletion({
+      model: BASE_MODEL, apiKey: 'k', messages: MSGS, temperature: 0.7,
+    });
+    expect(anthropicStream.mock.calls[0][0]).toHaveProperty('temperature', 0.7);
+  });
+
+  test('omits temperature for known no-temp models', async () => {
+    await new AnthropicAdapter().createStreamCompletion({
+      model: NO_TEMP_MODEL, apiKey: 'k', messages: MSGS, temperature: 0.7,
+    });
+    expect(anthropicStream.mock.calls[0][0]).not.toHaveProperty('temperature');
+  });
+
+  test('retries without temperature when streaming yields 400 "deprecated" error', async () => {
+    const Anthropic = jest.requireMock('@anthropic-ai/sdk').default;
+    const err = new Anthropic.BadRequestError('`temperature` is deprecated for this model.');
+
+    // First stream: finalMessage() rejects with BadRequestError
+    const failingStream = { finalMessage: jest.fn().mockRejectedValueOnce(err) };
+    const successStream = makeMockStream(GOOD_RESP);
+    anthropicStream
+      .mockReturnValueOnce(failingStream)
+      .mockReturnValue(successStream);
+
+    const result = await new AnthropicAdapter().createStreamCompletion({
+      model: BASE_MODEL, apiKey: 'k', messages: MSGS, temperature: 0.7,
+    });
+
+    expect(anthropicStream).toHaveBeenCalledTimes(2);
+    // First call: temperature included
+    expect(anthropicStream.mock.calls[0][0]).toHaveProperty('temperature');
+    // Retry call: temperature omitted
+    expect(anthropicStream.mock.calls[1][0]).not.toHaveProperty('temperature');
     expect(mockLog.warn).toHaveBeenCalledTimes(1);
     expect(result.completion).toBeDefined();
   });

--- a/__tests__/backend/services/model/adapters/maxTokens.test.ts
+++ b/__tests__/backend/services/model/adapters/maxTokens.test.ts
@@ -21,7 +21,11 @@ jest.mock('@/backend/services/model/openaiClient', () => {
 // Mock the Anthropic SDK (default export is the client constructor).
 jest.mock('@anthropic-ai/sdk', () => {
   const create = jest.fn();
-  const Anthropic = jest.fn().mockImplementation(() => ({ messages: { create } }));
+  const retrieve = jest.fn();
+  const Anthropic = jest.fn().mockImplementation(() => ({
+    messages: { create },
+    models: { retrieve },
+  }));
   return { __esModule: true, default: Anthropic, __create: create };
 });
 

--- a/src/backend/services/model/adapters/anthropicAdapter.ts
+++ b/src/backend/services/model/adapters/anthropicAdapter.ts
@@ -13,6 +13,14 @@ const log = createLogger('backend/services/model/adapters/anthropicAdapter');
 // resolved it is used verbatim, so larger caps are honored (issue #173).
 const DEFAULT_MAX_TOKENS = 8192;
 
+const CAPABILITY_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const modelCapabilityCache = new Map<string, { supportsTemperature: boolean; expiresAt: number }>();
+
+/** Clears the capability cache. Call in tests between cases. */
+export function clearModelCapabilityCache(): void {
+  modelCapabilityCache.clear();
+}
+
 /**
  * Static denylist of model-name substrings that no longer accept the
  * `temperature` sampling parameter (Anthropic deprecated it for adaptive-
@@ -25,7 +33,7 @@ const DEFAULT_MAX_TOKENS = 8192;
  *   that the retry path catches; a missing temperature on a model that wants it
  *   would silently change behaviour.
  */
-const TEMPERATURE_DEPRECATED_SUBSTRINGS = [
+export const TEMPERATURE_DEPRECATED_SUBSTRINGS = [
   'claude-opus-4-7',
   'claude-opus-4-8',
   'claude-opus-4-9',
@@ -35,13 +43,72 @@ const TEMPERATURE_DEPRECATED_SUBSTRINGS = [
   'claude-haiku-5',
 ] as const;
 
+async function fetchTemperatureSupportFromApi(
+  client: Anthropic,
+  modelName: string
+): Promise<boolean | null> {
+  try {
+    const model = await client.models.retrieve(modelName);
+    const caps = (model as unknown as Record<string, unknown>)['capabilities'] as Record<string, unknown> | undefined;
+    const thinking = caps?.['thinking'] as Record<string, unknown> | undefined;
+    const types = thinking?.['types'] as Record<string, unknown> | undefined;
+    const adaptive = types?.['adaptive'] as Record<string, unknown> | undefined;
+    if (typeof adaptive?.['supported'] === 'boolean') {
+      // adaptive.supported === true → model uses only adaptive thinking → no temperature
+      return !adaptive['supported'];
+    }
+    return null; // capability field absent — unknown
+  } catch {
+    return null; // API unavailable or model not returned — fall back to static list
+  }
+}
+
 /**
  * Returns true when the Anthropic model is expected to accept the `temperature`
  * parameter; false for models that reject it with a 400.
+ *
+ * Resolution order:
+ * 1. Cache hit (keyed by lowercase model name, TTL 5 min).
+ * 2. Live API lookup via client.models.retrieve (when client is provided).
+ * 3. Static denylist fallback (TEMPERATURE_DEPRECATED_SUBSTRINGS).
  */
-export function anthropicModelSupportsTemperature(modelName: string): boolean {
-  const lower = modelName.toLowerCase();
-  return !TEMPERATURE_DEPRECATED_SUBSTRINGS.some(s => lower.includes(s));
+export async function anthropicModelSupportsTemperature(
+  modelName: string,
+  client?: Anthropic
+): Promise<boolean> {
+  const key = modelName.toLowerCase();
+
+  // 1. Cache hit
+  const cached = modelCapabilityCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.supportsTemperature;
+  }
+
+  // 2. Live API lookup
+  if (client) {
+    const apiResult = await fetchTemperatureSupportFromApi(client, modelName);
+    if (apiResult !== null) {
+      modelCapabilityCache.set(key, {
+        supportsTemperature: apiResult,
+        expiresAt: Date.now() + CAPABILITY_CACHE_TTL_MS,
+      });
+      return apiResult;
+    }
+    log.debug(
+      'Anthropic Models API returned no temperature capability info; using static denylist',
+      { model: modelName }
+    );
+  }
+
+  // 3. Static denylist fallback
+  const staticResult = !TEMPERATURE_DEPRECATED_SUBSTRINGS.some(s => key.includes(s));
+  if (client) {
+    modelCapabilityCache.set(key, {
+      supportsTemperature: staticResult,
+      expiresAt: Date.now() + CAPABILITY_CACHE_TTL_MS,
+    });
+  }
+  return staticResult;
 }
 
 /**
@@ -245,7 +312,10 @@ export class AnthropicAdapter implements CompletionAdapter {
     const { system, messages: anthropicMessages } = toAnthropicMessages(messages);
     const anthropicTools = toAnthropicTools(tools);
 
-    const includeTemperature = anthropicModelSupportsTemperature(model.name);
+    // NOTE: anthropicModelSupportsTemperature is now async (issue #275): it first
+    // checks a short-lived cache, then queries the Anthropic Models API for
+    // live capability data, and finally falls back to the static denylist.
+    const includeTemperature = await anthropicModelSupportsTemperature(model.name, client);
     const params: Anthropic.MessageCreateParamsNonStreaming = {
       model: model.name,
       max_tokens: maxTokens ?? DEFAULT_MAX_TOKENS,
@@ -282,6 +352,88 @@ export class AnthropicAdapter implements CompletionAdapter {
         const paramsWithoutTemp = { ...params };
         delete (paramsWithoutTemp as Partial<typeof paramsWithoutTemp>).temperature;
         resp = await client.messages.create(paramsWithoutTemp, signal ? { signal } : undefined);
+      } else {
+        throw err;
+      }
+    }
+    return { completion: toChatCompletion(model.name, resp) };
+  }
+
+  /**
+   * Streaming variant of createCompletion: uses the Anthropic SDK's
+   * client.messages.stream() helper to open a native streaming connection,
+   * then collects the final assembled Message via stream.finalMessage().
+   *
+   * AUDIT NOTE (issue #274): As of the audit at baseSha
+   * 18dbcbbbf7223aba499f4bc8f5489e5a52010ef8 there was no streaming branch in
+   * this adapter. This method adds one proactively so that the same temperature
+   * guard and catch-and-retry applied to createCompletion cannot be bypassed by
+   * callers that prefer native SDK streaming.
+   *
+   * The interface contract is identical to createCompletion: callers receive a
+   * CompletionResult containing an OpenAI-shaped ChatCompletion.
+   */
+  async createStreamCompletion({
+    model,
+    apiKey,
+    messages,
+    tools,
+    temperature,
+    maxTokens,
+    signal,
+  }: CompletionInput): Promise<CompletionResult> {
+    const client = new Anthropic({
+      apiKey,
+      ...(model.baseUrl ? { baseURL: model.baseUrl } : {}),
+      timeout: LLM_REQUEST_TIMEOUT_MS,
+    });
+
+    const { system, messages: anthropicMessages } = toAnthropicMessages(messages);
+    const anthropicTools = toAnthropicTools(tools);
+
+    // NOTE: anthropicModelSupportsTemperature is now async (changed by issue #275).
+    const includeTemperature = await anthropicModelSupportsTemperature(model.name, client);
+    const params: Anthropic.MessageCreateParamsNonStreaming = {
+      model: model.name,
+      max_tokens: maxTokens ?? DEFAULT_MAX_TOKENS,
+      ...(includeTemperature ? { temperature } : {}),
+      messages: anthropicMessages,
+      ...(system ? { system } : {}),
+      ...(anthropicTools ? { tools: anthropicTools } : {}),
+    };
+
+    log.debug('createStreamCompletion via Anthropic SDK', {
+      model: model.name,
+      toolCount: anthropicTools?.length ?? 0,
+      hasSystem: Boolean(system),
+    });
+
+    let resp: Anthropic.Message;
+    try {
+      const stream = client.messages.stream(
+        params as Parameters<typeof client.messages.stream>[0],
+        signal ? { signal } : undefined
+      );
+      resp = await stream.finalMessage();
+    } catch (err) {
+      if (
+        err instanceof Anthropic.BadRequestError &&
+        err.message.includes('temperature') &&
+        err.message.toLowerCase().includes('deprecated') &&
+        'temperature' in params
+      ) {
+        log.warn(
+          'Anthropic API (streaming) rejected temperature for model; retrying without it. ' +
+            'Consider adding this model to TEMPERATURE_DEPRECATED_SUBSTRINGS.',
+          { model: model.name }
+        );
+        const paramsWithoutTemp = { ...params };
+        delete (paramsWithoutTemp as Partial<typeof paramsWithoutTemp>).temperature;
+        const retryStream = client.messages.stream(
+          paramsWithoutTemp as Parameters<typeof client.messages.stream>[0],
+          signal ? { signal } : undefined
+        );
+        resp = await retryStream.finalMessage();
       } else {
         throw err;
       }

--- a/src/backend/services/model/adapters/types.ts
+++ b/src/backend/services/model/adapters/types.ts
@@ -159,4 +159,10 @@ export interface CompletionResult {
  */
 export interface CompletionAdapter {
   createCompletion(input: CompletionInput): Promise<CompletionResult>;
+  /**
+   * Optional streaming variant. Adapters that support native SDK streaming
+   * (currently only AnthropicAdapter) implement this. Returns the same
+   * CompletionResult shape as createCompletion.
+   */
+  createStreamCompletion?(input: CompletionInput): Promise<CompletionResult>;
 }


### PR DESCRIPTION
## Summary

Two related improvements to the Anthropic Native adapter (applied sequentially):

**Plan 275 — Dynamic capability detection** replaces the static `TEMPERATURE_DEPRECATED_SUBSTRINGS` denylist with a live query to the Anthropic Models API (`client.models.retrieve(modelId)`) that reads `capabilities.thinking.types.adaptive.supported`. Results are cached for 5 minutes. If the API is unavailable or returns no capability data, the static denylist acts as a fallback. `anthropicModelSupportsTemperature` becomes `async` and accepts an optional `client` parameter.

**Plan 274 — Streaming temperature guard** audits the streaming path and adds a proactive `createStreamCompletion` method (using `client.messages.stream()`) that applies the same temperature guard and catch-and-retry logic from the start, preventing future callers from bypassing it.

## Files touched

- `src/backend/services/model/adapters/anthropicAdapter.ts` — async capability detection with cache, `createStreamCompletion` method
- `src/backend/services/model/adapters/types.ts` — optional `createStreamCompletion?` on `CompletionAdapter`
- `__tests__/backend/services/model/adapters/anthropicTemperature.test.ts` — extended mock (retrieve + stream), dynamic-capability describe block (≥5 tests), streaming describe block (3 tests)
- `__tests__/backend/services/model/adapters/maxTokens.test.ts` — add `models: { retrieve: jest.fn() }` to mock

## How to verify

1. Run `npm test -- __tests__/backend/services/model/adapters/` — all tests pass including new dynamic-capability and streaming groups.
2. `clearModelCapabilityCache` import present in test file; `anthropicRetrieve` called exactly once for repeated model lookups (cache test).
3. `createStreamCompletion` in adapter uses `client.messages.stream()` not `.create`; both `createCompletion` and `createStreamCompletion` `await anthropicModelSupportsTemperature(model.name, client)`.

Closes https://github.com/mario-andreschak/FLUJO/issues/275
Closes https://github.com/mario-andreschak/FLUJO/issues/274