### PR TITLE
chore: delete dead isRetryableError helper from chatCompletionService

### DIFF
--- a/src/app/v1/chat/completions/chatCompletionService.ts
+++ b/src/app/v1/chat/completions/chatCompletionService.ts
@@ -23,17 +23,6 @@ export function countTokens(text: string): number {
 // Using OpenAI's type for token usage - Keep as is
 export type TokenUsage = OpenAI.CompletionUsage;
 
-// isRetryableError - Keep as is
-export function isRetryableError(error: any): boolean {
-  log.verbose('Checking if error is retryable', { errorType: typeof error, status: error.status, code: error.code, message: error.message }); // Changed to verbose
-  if (error.status === 429) return true;
-  if (error.status >= 500 && error.status < 600) return true;
-  if (error.message?.includes('timeout') || error.code === 'ETIMEDOUT') return true;
-  if (error.code === 'ECONNREFUSED' || error.code === 'ECONNRESET') return true;
-  log.verbose('Error is not retryable', { error }); // Changed to verbose
-  return false;
-}
-
 // Persist conversation state WITHOUT the in-memory-only debug execution trace
 // (keeps the on-disk conversation lean). See persistConversationState.
 const persistState = persistConversationState;


### PR DESCRIPTION
## Summary

`isRetryableError` in `src/app/v1/chat/completions/chatCompletionService.ts` is an orphaned helper that is exported but never imported or called anywhere in the codebase. The canonical retry utility is now `isTransientTransportError` / `withTransientRetry` in `src/backend/utils/transientRetry.ts` (introduced in the ECONNRESET retry PR). This PR removes the dead code.

## Files touched

- `src/app/v1/chat/completions/chatCompletionService.ts` — deletes the `isRetryableError` function block (10 lines including the comment)

## How to verify

1. Open `src/app/v1/chat/completions/chatCompletionService.ts` — confirm no `isRetryableError` definition exists.
2. A codebase-wide search for `isRetryableError` returns zero matches.
3. Run `npm test` — all existing tests pass (none reference `isRetryableError`).
4. No user-visible behaviour change.

Closes https://github.com/mario-andreschak/FLUJO/issues/273