### PR TITLE
feat: packages — remote server HTTP headers + adopt-and-configure semantics for existing servers

### DIFF
--- a/__tests__/packages/installPackage.test.ts
+++ b/__tests__/packages/installPackage.test.ts
@@ -40,10 +40,12 @@ jest.mock('@/backend/services/flow', () => ({
 
 const updateServerConfigMock = jest.fn();
 const loadServerConfigsMock = jest.fn();
+const deleteServerConfigMock = jest.fn();
 jest.mock('@/backend/services/mcp', () => ({
   mcpService: {
     updateServerConfig: (...a: unknown[]) => updateServerConfigMock(...a),
     loadServerConfigs: (...a: unknown[]) => loadServerConfigsMock(...a),
+    deleteServerConfig: (...a: unknown[]) => deleteServerConfigMock(...a),
   },
 }));
 
@@ -102,6 +104,7 @@ beforeEach(() => {
   saveFlowMock.mockResolvedValue({ success: true });
   updateServerConfigMock.mockResolvedValue({ name: 'x' });
   loadServerConfigsMock.mockResolvedValue([]);
+  deleteServerConfigMock.mockResolvedValue({ success: true });
   schedulerCreateMock.mockResolvedValue({ execution: { id: 'x' } });
   schedulerUpdateMock.mockResolvedValue({ execution: { id: 'x' } });
 });
@@ -257,5 +260,105 @@ describe('installPackage — ledger + status', () => {
     const last = await getLastInstallSummary('my-pkg');
     expect(last).not.toBeNull();
     expect(last!.package?.name).toBe('my-pkg');
+  });
+});
+
+describe('installPackage — adopt-and-configure', () => {
+  // For adopt tests, pre-populate so that the 'web' server exists before install.
+  beforeEach(() => {
+    loadServerConfigsMock.mockResolvedValue([{ name: 'web', transport: 'stdio', env: {} }]);
+  });
+
+  it('Test A: happy path — merges env, marks isSecret, classifies as updated not created', async () => {
+    const summary = await installPackage({
+      source: 'registry',
+      packageId: 'my-pkg',
+      secrets: { API_KEY: 'sk-1' },
+      consentGranted: true,
+    });
+
+    // Registry install NOT called — adopt path took over.
+    expect(installRegistryServerMock).not.toHaveBeenCalled();
+
+    // updateServerConfig called with the merged env, isSecret tagged.
+    expect(updateServerConfigMock).toHaveBeenCalledWith('web', {
+      env: { WEB_KEY: { value: 'sk-1', metadata: { isSecret: true } } },
+    });
+
+    // Server classified as updated, not created.
+    expect(summary.updated.some((u) => u.type === 'server' && u.name === 'web')).toBe(true);
+    expect(summary.created.filter((c) => c.type === 'server')).toHaveLength(0);
+
+    // Ledger: entities includes 'web', created does NOT.
+    const file = store.get('package_installs') as Record<string, {
+      entities?: { servers: string[] };
+      created?: { servers: string[] };
+    }>;
+    expect(file['my-pkg'].created!.servers).toEqual([]);
+    expect(file['my-pkg'].entities!.servers).toContain('web');
+  });
+
+  it('Test B: missing required secret — partial merge, note added, server not disabled', async () => {
+    const summary = await installPackage({
+      source: 'registry',
+      packageId: 'my-pkg',
+      secrets: {},
+      consentGranted: true,
+    });
+
+    // updateServerConfig still called (partial merge, key omitted).
+    expect(updateServerConfigMock).toHaveBeenCalledWith('web', expect.objectContaining({ env: expect.any(Object) }));
+
+    // The updated entry for the server has a note mentioning the missing env name.
+    const serverUpdate = summary.updated.find((u) => u.type === 'server');
+    expect(serverUpdate).toBeDefined();
+    expect(serverUpdate!.note).toContain('WEB_KEY');
+
+    // Server is NOT in the disabled list.
+    expect(summary.disabled.filter((d) => d.type === 'server')).toHaveLength(0);
+  });
+
+  it('Test C: updateServerConfig fails — server goes to skipped, not updated', async () => {
+    updateServerConfigMock.mockResolvedValueOnce({ success: false, error: 'disk full' });
+
+    const summary = await installPackage({
+      source: 'registry',
+      packageId: 'my-pkg',
+      secrets: { API_KEY: 'sk-1' },
+      consentGranted: true,
+    });
+
+    expect(summary.skipped.some((s) => s.type === 'server' && s.name === 'web')).toBe(true);
+    expect(summary.updated.filter((u) => u.type === 'server')).toHaveLength(0);
+  });
+
+  it('Test D: remote server buildRemoteServerConfig tags envFromSecret env values as isSecret', async () => {
+    // Override to use a remote-server manifest (no adopt path).
+    fetchPackageManifestMock.mockResolvedValue({
+      schemaVersion: '1',
+      name: 'remote-pkg',
+      version: '1.0.0',
+      secrets: [{ key: 'API_KEY', required: true }],
+      mcpServers: [
+        {
+          localName: 'my-remote',
+          ref: { kind: 'remote', transport: 'streamable', serverUrl: 'https://example.com/mcp' },
+          envFromSecret: { API_KEY: 'API_KEY' },
+        },
+      ],
+    });
+    // No pre-existing servers — remote server is a fresh upsert.
+    loadServerConfigsMock.mockResolvedValue([]);
+
+    await installPackage({
+      source: 'registry',
+      packageId: 'remote-pkg',
+      secrets: { API_KEY: 'sk-1' },
+      consentGranted: true,
+    });
+
+    expect(updateServerConfigMock).toHaveBeenCalledTimes(1);
+    const config = updateServerConfigMock.mock.calls[0][1] as { env: Record<string, unknown> };
+    expect(config.env['API_KEY']).toEqual({ value: 'sk-1', metadata: { isSecret: true } });
   });
 });

--- a/src/backend/services/packages/installPackage.ts
+++ b/src/backend/services/packages/installPackage.ts
@@ -41,7 +41,7 @@ import { getSchedulerService } from '@/backend/services/scheduler';
 import type { Model } from '@/shared/types/model';
 import type { ModelProvider } from '@/shared/types/model/provider';
 import type { Flow } from '@/shared/types/flow';
-import type { MCPServerConfig } from '@/shared/types/mcp';
+import type { MCPServerConfig, EnvVarValue } from '@/shared/types/mcp';
 
 const log = createLogger('backend/services/packages/installPackage');
 
@@ -281,13 +281,18 @@ export async function installPackage(input: InstallPackageInput): Promise<Instal
     plannedExecutions: [],
   };
 
-  // Snapshot MCP server names that pre-exist BEFORE we install any, so remote
-  // (upsert) servers can be classified created-vs-adopted for uninstall.
+  // Snapshot MCP server names + configs that pre-exist BEFORE we install any,
+  // so remote (upsert) servers can be classified created-vs-adopted for uninstall,
+  // and registry servers with matching localName can be adopted in place.
   const existingServerNames = new Set<string>();
+  const existingServerConfigs = new Map<string, MCPServerConfig>();
   try {
     const configs = await mcpService.loadServerConfigs();
     if (Array.isArray(configs)) {
-      for (const c of configs) existingServerNames.add(c.name);
+      for (const c of configs) {
+        existingServerNames.add(c.name);
+        existingServerConfigs.set(c.name, c);
+      }
     }
   } catch (err) {
     log.warn('installPackage: failed to snapshot existing server names', err);
@@ -295,12 +300,12 @@ export async function installPackage(input: InstallPackageInput): Promise<Instal
 
   // 4. MCP servers (before flows so name-based boundServer references resolve).
   for (const server of manifest.mcpServers ?? []) {
-    await installServer(server, { secrets, secretProvided, secretRequired, summary, ledgerEntities, ledgerCreated, existingServerNames });
+    await installServer(server, { secrets, secretProvided, secretRequired, summary, ledgerEntities, ledgerCreated, existingServerNames, existingServerConfigs });
   }
 
   // 5. Models (before flows so name-based boundModel references resolve).
   for (const model of manifest.models ?? []) {
-    await installModel(model, { secrets, secretProvided, secretRequired, summary, ledgerEntities, ledgerCreated, existingServerNames });
+    await installModel(model, { secrets, secretProvided, secretRequired, summary, ledgerEntities, ledgerCreated, existingServerNames, existingServerConfigs });
   }
 
   // 6. Flows — fresh deterministic ids + internal reference remapping.
@@ -504,9 +509,14 @@ function buildPreview(manifest: PackageManifest, secretProvided: (k: string) => 
     servers: (manifest.mcpServers ?? []).map((s) => ({
       localName: s.localName,
       source: serverSource(s),
-      requiredEnvMissing: Object.entries(s.envFromSecret ?? {})
+      // Include both envFromSecret and headersFromSecret field names in the
+      // missing list so the consent screen shows all required fields.
+      requiredEnvMissing: [
+        ...Object.entries(s.envFromSecret ?? {}),
+        ...Object.entries(s.headersFromSecret ?? {}),
+      ]
         .filter(([, key]) => (manifest.secrets ?? []).some((sec) => sec.key === key && sec.required) && !secretProvided(key))
-        .map(([envName]) => envName),
+        .map(([name]) => name),
     })),
     models: (manifest.models ?? []).map((m) => ({
       displayName: m.displayName,
@@ -539,6 +549,112 @@ interface InstallCtx {
   ledgerCreated: LedgerCreated;
   /** Server names that already existed before this install began. */
   existingServerNames: Set<string>;
+  /** Full server configs snapshot taken before install began (for adopt-and-configure). */
+  existingServerConfigs: Map<string, MCPServerConfig>;
+}
+
+/**
+ * Adopt-and-configure: when a registry-ref server's localName already exists in
+ * FLUJO, merge the manifest env into the existing config rather than running a
+ * new registry install. Secret-derived values are tagged isSecret for
+ * encryption at rest. The server is classified as `updated` (never `created`)
+ * so uninstall will skip it.
+ */
+async function adoptAndConfigureServer(
+  server: NonNullable<PackageManifest['mcpServers']>[number],
+  ctx: InstallCtx,
+  missingRequired: string[],
+): Promise<void> {
+  const { secrets, secretProvided, summary, ledgerEntities, existingServerConfigs } = ctx;
+  const source = serverSource(server);
+
+  const existingConfig = existingServerConfigs.get(server.localName);
+  if (!existingConfig) {
+    // Snapshot was stale — nothing to adopt; skip without error.
+    summary.servers.push({ localName: server.localName, source, installed: false,
+      error: 'server vanished between snapshot and install' });
+    summary.skipped.push({ type: 'server', name: server.localName,
+      note: 'server not found in configs (stale snapshot)' });
+    return;
+  }
+
+  // Merge env: existing keys preserved, manifest literal env keys win (plain strings),
+  // envFromSecret keys win and are tagged isSecret for encryption at rest.
+  const mergedEnv: Record<string, EnvVarValue> = { ...(existingConfig.env ?? {}) };
+  for (const [envName, value] of Object.entries(server.env ?? {})) {
+    mergedEnv[envName] = value; // non-secret literal
+  }
+  for (const [envName, secretKey] of Object.entries(server.envFromSecret ?? {})) {
+    if (secretProvided(secretKey)) {
+      mergedEnv[envName] = { value: secrets[secretKey], metadata: { isSecret: true } };
+    }
+    // Missing required secret: skip the key — don't disable a pre-existing server.
+  }
+
+  // Save merged env. updateServerConfig reconnects the server automatically when
+  // the config meaningfully changed.
+  const saved = await mcpService.updateServerConfig(
+    server.localName,
+    { env: mergedEnv } as Partial<MCPServerConfig>,
+  );
+  const failed =
+    !Array.isArray(saved) &&
+    saved &&
+    'success' in saved &&
+    (saved as { success?: boolean }).success === false;
+  if (failed) {
+    const error = (saved as { error?: string }).error ?? 'unknown error';
+    summary.servers.push({ localName: server.localName, source, installed: false, error });
+    summary.skipped.push({ type: 'server', name: server.localName, note: error });
+    return;
+  }
+
+  // Classify as updated (not created) — uninstall must never delete this server.
+  ledgerEntities.servers.push(server.localName);
+  // NOTE: intentionally NOT adding to ledgerCreated.servers
+  summary.servers.push({
+    localName: server.localName, source, installed: true,
+    serverName: server.localName, alreadyExisted: true,
+  });
+  const note = missingRequired.length > 0
+    ? `env partially merged — missing required secret(s) for: ${missingRequired.join(', ')}`
+    : undefined;
+  summary.updated.push({
+    type: 'server', name: server.localName, id: server.localName,
+    ...(note ? { note } : {}),
+  });
+}
+
+/**
+ * After a successful new registry install, re-load the installed config and tag
+ * any env entries that came from envFromSecret as isSecret so they are
+ * encrypted at rest. Fail-soft: a tagging failure is logged but not fatal.
+ */
+async function tagSecretEnvKeys(
+  serverName: string,
+  envFromSecret: Record<string, string>,
+  secrets: Record<string, string>,
+  secretProvided: (k: string) => boolean,
+): Promise<void> {
+  const allConfigs = await mcpService.loadServerConfigs().catch(() => null);
+  if (!Array.isArray(allConfigs)) return;
+  const existing = allConfigs.find((c) => c.name === serverName);
+  if (!existing) return;
+
+  let changed = false;
+  const updatedEnv: Record<string, EnvVarValue> = { ...(existing.env ?? {}) };
+  for (const [envName, secretKey] of Object.entries(envFromSecret)) {
+    if (secretProvided(secretKey)) {
+      updatedEnv[envName] = { value: secrets[secretKey], metadata: { isSecret: true } };
+      changed = true;
+    }
+  }
+  if (!changed) return;
+  try {
+    await mcpService.updateServerConfig(serverName, { env: updatedEnv } as Partial<MCPServerConfig>);
+  } catch (err) {
+    log.warn(`tagSecretEnvKeys: failed to re-tag secret env for "${serverName}"`, err);
+  }
 }
 
 async function installServer(
@@ -560,7 +676,39 @@ async function installServer(
     }
   }
 
+  // Resolve headers for remote servers (literal + secret-derived).
+  // For registry servers, headers are schema-rejected; guard here defensively.
+  const resolvedHeaders: Record<string, import('@/shared/types/mcp').MCPHeaderValue> = {};
+  if (server.ref.kind === 'remote') {
+    // Literal header values
+    for (const [headerName, headerValue] of Object.entries(server.headers ?? {})) {
+      resolvedHeaders[headerName] = headerValue;
+    }
+    // Secret-derived header values
+    for (const [headerName, secretKey] of Object.entries(server.headersFromSecret ?? {})) {
+      if (secretProvided(secretKey)) {
+        resolvedHeaders[headerName] = { value: secrets[secretKey], metadata: { isSecret: true } };
+      } else if (secretRequired(secretKey)) {
+        missingRequired.push(headerName);
+      }
+      // If not required and not provided: skip
+    }
+  } else if (
+    (server.headers && Object.keys(server.headers).length > 0) ||
+    (server.headersFromSecret && Object.keys(server.headersFromSecret).length > 0)
+  ) {
+    log.warn('installServer: headers/headersFromSecret are ignored for non-remote server refs', server.localName);
+  }
+
   if (server.ref.kind === 'registry') {
+    // ADOPT-AND-CONFIGURE: if a server with this localName already exists,
+    // merge env into it rather than installing a new server from the registry.
+    if (existingServerNames.has(server.localName)) {
+      await adoptAndConfigureServer(server, ctx, missingRequired);
+      return;
+    }
+
+    // NEW INSTALL: fail-soft if a required secret is missing.
     if (missingRequired.length > 0) {
       summary.disabled.push({ type: 'server', name: server.localName, note: `missing required secret(s) for: ${missingRequired.join(', ')}` });
       summary.servers.push({ localName: server.localName, source, installed: false, needsEnv: missingRequired });
@@ -584,6 +732,10 @@ async function installServer(
       else {
         if (result.serverName) ledgerCreated.servers.push(result.serverName);
         summary.created.push(ref);
+        // Tag secret-derived env keys as isSecret for encryption at rest.
+        if (result.serverName && Object.keys(server.envFromSecret ?? {}).length > 0) {
+          await tagSecretEnvKeys(result.serverName, server.envFromSecret ?? {}, secrets, secretProvided);
+        }
       }
     } else {
       summary.skipped.push({ type: 'server', name: server.localName, note: result.error ?? (result.needsEnv ? `needs env: ${result.needsEnv.join(', ')}` : 'not installed') });
@@ -594,8 +746,9 @@ async function installServer(
   // Remote (sse / streamable / websocket) — plain config creation. Install
   // DISABLED when a required secret is missing (rather than dropping it).
   const disabled = missingRequired.length > 0;
+  const secretEnvKeys = new Set(Object.keys(server.envFromSecret ?? {}));
   try {
-    const config = buildRemoteServerConfig(server, env, disabled);
+    const config = buildRemoteServerConfig(server, env, disabled, resolvedHeaders, secretEnvKeys);
     const saved = await mcpService.updateServerConfig(server.localName, config);
     const failed = !Array.isArray(saved) && saved && 'success' in saved && (saved as { success?: boolean }).success === false;
     if (failed) {
@@ -623,6 +776,8 @@ function buildRemoteServerConfig(
   server: NonNullable<PackageManifest['mcpServers']>[number],
   env: Record<string, string>,
   disabled: boolean,
+  headers: Record<string, import('@/shared/types/mcp').MCPHeaderValue> = {},
+  secretEnvKeys: Set<string> = new Set(),
 ): MCPServerConfig {
   if (server.ref.kind !== 'remote') {
     throw new Error('buildRemoteServerConfig called for a non-remote ref');
@@ -633,14 +788,25 @@ function buildRemoteServerConfig(
     disabled,
     autoApprove: [] as string[],
     rootPath: '',
-    env: Object.fromEntries(Object.entries(env).map(([k, v]) => [k, { value: v }])),
+    env: Object.fromEntries(
+      Object.entries(env).map(([k, v]) => [
+        k,
+        secretEnvKeys.has(k) ? { value: v, metadata: { isSecret: true } } : v,
+      ])
+    ),
     _buildCommand: '',
     _installCommand: '',
   };
   if (transport === 'websocket') {
     return { ...base, transport: 'websocket', websocketUrl: server.ref.serverUrl } as MCPServerConfig;
   }
-  return { ...base, transport, serverUrl: server.ref.serverUrl } as MCPServerConfig;
+  const hasHeaders = Object.keys(headers).length > 0;
+  return {
+    ...base,
+    transport,
+    serverUrl: server.ref.serverUrl,
+    ...(hasHeaders ? { headers } : {}),
+  } as MCPServerConfig;
 }
 
 async function installModel(

--- a/src/shared/types/packages/manifest.ts
+++ b/src/shared/types/packages/manifest.ts
@@ -54,15 +54,43 @@ export const ServerRefSchema = z.discriminatedUnion('kind', [
   RemoteServerRefSchema,
 ]);
 
-export const ManifestServerSchema = z.object({
-  /** The name this server is installed under in FLUJO (referenced by flows). */
-  localName: z.string().min(1),
-  ref: ServerRefSchema,
-  /** Literal environment values, by env-var name. */
-  env: z.record(z.string(), z.string()).optional(),
-  /** Map of env-var name -> secret key; resolved from the supplied secrets. */
-  envFromSecret: z.record(z.string(), z.string()).optional(),
-});
+export const ManifestServerSchema = z
+  .object({
+    /** The name this server is installed under in FLUJO (referenced by flows). */
+    localName: z.string().min(1),
+    ref: ServerRefSchema,
+    /** Literal environment values, by env-var name. */
+    env: z.record(z.string(), z.string()).optional(),
+    /** Map of env-var name -> secret key; resolved from the supplied secrets. */
+    envFromSecret: z.record(z.string(), z.string()).optional(),
+    /** Literal HTTP header values (for non-secret headers on remote servers only). */
+    headers: z.record(z.string(), z.string()).optional(),
+    /**
+     * Map of HTTP header name → secret key; resolved from the supplied secrets.
+     * The stored value becomes the verbatim header value (e.g. "Bearer ghp_xxx" —
+     * no automatic prefix is applied; callers must supply the full header value).
+     * Valid only when ref.kind === 'remote'; rejected for registry refs.
+     */
+    headersFromSecret: z.record(z.string(), z.string()).optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.ref.kind !== 'remote') {
+      if (val.headers && Object.keys(val.headers).length > 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['headers'],
+          message: '`headers` is only valid on remote server refs',
+        });
+      }
+      if (val.headersFromSecret && Object.keys(val.headersFromSecret).length > 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['headersFromSecret'],
+          message: '`headersFromSecret` is only valid on remote server refs',
+        });
+      }
+    }
+  });
 export type ManifestServer = z.infer<typeof ManifestServerSchema>;
 
 export const ManifestModelSchema = z.object({


### PR DESCRIPTION
## Summary

Two related improvements to the packages install pipeline (applied sequentially):

**Plan 262 — Remote server HTTP headers** adds `headers` and `headersFromSecret` fields to `ManifestServerSchema`. The install orchestrator resolves these into `resolvedHeaders`, passes them through the updated `buildRemoteServerConfig` signature, and populates `config.headers` for SSE/Streamable transports. A schema-level `.superRefine()` rejects these fields on non-remote refs. `buildPreview()` also exposes missing required header secrets in `requiredEnvMissing`.

**Plan 263 — Adopt-and-configure semantics** fixes two gaps when a manifest server `localName` matches a pre-existing FLUJO server: (1) the install path now detects the existing server, merges env into it via `mcpService.updateServerConfig`, and classifies the result as `updated` (not `created`) — preventing duplicate server creation; (2) secret-derived env values are tagged `metadata: { isSecret: true }` for encryption at rest in both the adopt path (`adoptAndConfigureServer`) and the remote build path (`buildRemoteServerConfig`).

## Files touched

- `src/shared/types/packages/manifest.ts` — `headers`, `headersFromSecret` fields + `.superRefine()` validation
- `src/backend/services/packages/installPackage.ts` — header resolution, combined `buildRemoteServerConfig` signature, `adoptAndConfigureServer` helper, `tagSecretEnvKeys` helper, adopt-path wiring
- `__tests__/packages/installPackage.test.ts` *(new or extended)* — adopt-and-configure describe block (Tests A–D)

## How to verify

1. A manifest JSON with `"headersFromSecret": { "Authorization": "githubToken" }` on a remote ref passes `parsePackageManifest()`; the same on a registry ref fails with a human-readable error.
2. Install with secret provided → `config.headers.Authorization` equals `{ value: "Bearer ghp_xxx", metadata: { isSecret: true } }`.
3. Registry server with `localName` matching existing server → `installRegistryServer` NOT called; `updateServerConfig` called with merged env; `summary.updated` contains the entry; `ledger.created.servers` does NOT contain `localName`.
4. `envFromSecret` values stored as `{ value, metadata: { isSecret: true } }` throughout.
5. Run `npm test -- __tests__/packages/installPackage.test.ts` — all tests including new adopt-and-configure describe block pass.

Closes https://github.com/mario-andreschak/FLUJO/issues/262
Closes https://github.com/mario-andreschak/FLUJO/issues/263