### PR TITLE
feat(model): prompt caching on the native Anthropic adapter

### DIFF
--- a/__tests__/model/anthropicPromptCache.test.ts
+++ b/__tests__/model/anthropicPromptCache.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Prompt caching on the native Anthropic path.
+ *
+ * The Anthropic Messages API caches NOTHING without explicit `cache_control`
+ * breakpoints (unlike the OpenAI-compatible path's automatic prefix cache), so
+ * before this the adapter re-read the whole prefix at full price on every turn of
+ * every agentic loop. These tests pin the three things that can regress:
+ *   - where the breakpoints land, and that placement is pure,
+ *   - that an endpoint which rejects `cache_control` degrades instead of failing,
+ *   - that the reported usage exposes the cache buckets, so the saving is visible
+ *     to the context meter and the prompt-cache metrics rather than invisible.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import OpenAI from 'openai';
+import {
+  AnthropicAdapter,
+  applyCacheBreakpoints,
+  isCacheControlRejection,
+  clearModelCapabilityCache,
+  __resetCacheControlSupport,
+} from '@/backend/services/model/adapters/anthropicAdapter';
+import { Model } from '@/shared/types/model';
+
+jest.mock('@/utils/logger', () => {
+  const log = { verbose: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  return { createLogger: () => log };
+});
+
+jest.mock('@anthropic-ai/sdk', () => {
+  const create = jest.fn();
+  const retrieve = jest.fn();
+  const stream = jest.fn();
+  const BadRequestError = class extends Error {
+    status = 400;
+    constructor(msg: string) { super(msg); }
+  };
+  const AnthropicMock = jest.fn().mockImplementation(() => ({
+    messages: { create, stream },
+    models: { retrieve },
+  }));
+  (AnthropicMock as any).BadRequestError = BadRequestError;
+  return { __esModule: true, default: AnthropicMock, __create: create, __retrieve: retrieve, __stream: stream };
+});
+
+const sdk = jest.requireMock('@anthropic-ai/sdk') as any;
+const anthropicCreate = sdk.__create;
+const anthropicRetrieve = sdk.__retrieve;
+const anthropicStream = sdk.__stream;
+
+const GOOD_RESP = {
+  id: 'a',
+  model: 'test',
+  content: [{ type: 'text', text: 'hi' }],
+  stop_reason: 'end_turn',
+  usage: { input_tokens: 10, output_tokens: 5 },
+};
+
+const MODEL: Model = { id: 'm', name: 'claude-3-5-sonnet-20241022', ApiKey: 'k' } as Model;
+const MSGS: OpenAI.ChatCompletionMessageParam[] = [
+  { role: 'system', content: 'You are helpful.' },
+  { role: 'user', content: 'hi' },
+];
+const TOOLS: OpenAI.ChatCompletionTool[] = [
+  { type: 'function', function: { name: 'a', parameters: { type: 'object', properties: {} } } },
+  { type: 'function', function: { name: 'b', parameters: { type: 'object', properties: {} } } },
+];
+
+/** The `cache_control` marker, as it appears on a marked block. */
+const EPHEMERAL = { type: 'ephemeral' };
+
+describe('applyCacheBreakpoints', () => {
+  const SYSTEM = 'You are helpful.';
+  const MESSAGES: Anthropic.MessageParam[] = [{ role: 'user', content: 'hi' }];
+  const ANTHROPIC_TOOLS: Anthropic.Tool[] = [
+    { name: 'a', input_schema: { type: 'object', properties: {} } },
+    { name: 'b', input_schema: { type: 'object', properties: {} } },
+  ];
+
+  test('marks the last tool, the system block, and the last message — three breakpoints', () => {
+    const out = applyCacheBreakpoints({
+      system: SYSTEM,
+      messages: MESSAGES,
+      tools: ANTHROPIC_TOOLS,
+    });
+
+    expect(out.breakpoints).toBe(3);
+
+    // 1. Last tool only — an inner breakpoint on every tool would waste slots.
+    expect(out.tools?.[0]).not.toHaveProperty('cache_control');
+    expect(out.tools?.[1]).toHaveProperty('cache_control', EPHEMERAL);
+
+    // 2. System is promoted from a string to a marked text block: the only shape
+    //    that can carry the marker.
+    expect(out.system).toEqual([
+      { type: 'text', text: SYSTEM, cache_control: EPHEMERAL },
+    ]);
+
+    // 3. Tail message string content is promoted to a marked block array.
+    expect(out.messages[0].content).toEqual([
+      { type: 'text', text: 'hi', cache_control: EPHEMERAL },
+    ]);
+  });
+
+  test('never mutates its inputs, so a retry can rebuild from the originals', () => {
+    const messages: Anthropic.MessageParam[] = [{ role: 'user', content: 'hi' }];
+    const tools: Anthropic.Tool[] = [{ name: 'a', input_schema: { type: 'object', properties: {} } }];
+
+    applyCacheBreakpoints({ system: SYSTEM, messages, tools });
+
+    expect(messages[0].content).toBe('hi');
+    expect(tools[0]).not.toHaveProperty('cache_control');
+  });
+
+  test('anchors the tail to the last block that can carry the marker', () => {
+    // A trailing block of an unmarkable type must not be marked; the breakpoint
+    // moves back to the tool_result, which caches a shorter (still valid) prefix.
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: 'ok' },
+          { type: 'some_future_block' },
+        ],
+      },
+    ] as unknown as Anthropic.MessageParam[];
+
+    const out = applyCacheBreakpoints({ messages });
+
+    const content = out.messages[0].content as Array<Record<string, unknown>>;
+    expect(content[0]).toHaveProperty('cache_control', EPHEMERAL);
+    expect(content[1]).not.toHaveProperty('cache_control');
+    expect(out.breakpoints).toBe(1);
+  });
+
+  test('skips the tail breakpoint on an empty turn (Anthropic rejects empty text blocks)', () => {
+    const out = applyCacheBreakpoints({
+      system: SYSTEM,
+      messages: [{ role: 'user', content: '' }],
+    });
+
+    expect(out.breakpoints).toBe(1); // system only — no tool block, no markable tail
+    expect(out.messages[0].content).toBe('');
+  });
+
+  test('places nothing when there is no system, no tools and no messages', () => {
+    const out = applyCacheBreakpoints({ messages: [] });
+    expect(out.breakpoints).toBe(0);
+    expect(out.system).toBeUndefined();
+    expect(out.tools).toBeUndefined();
+  });
+});
+
+describe('isCacheControlRejection', () => {
+  test('matches a 400 that names cache_control as unsupported', () => {
+    expect(isCacheControlRejection({ status: 400, message: 'Unsupported field: cache_control' })).toBe(true);
+    expect(isCacheControlRejection({ status: 422, message: 'unknown parameter cache_control' })).toBe(true);
+  });
+
+  test('does not match unrelated failures — they must propagate, not be retried', () => {
+    // Right shape, wrong field.
+        expect(isCacheControlRejection({ status: 400, message: 'Unsupported field: temperature' })).toBe(false);
+    // Names the field but is not an unsupported-parameter error (e.g. too many
+    // breakpoints) — silently retrying would mask a real bug.
+    expect(isCacheControlRejection({ status: 400, message: 'too many cache_control blocks' })).toBe(false);
+    expect(isCacheControlRejection({ status: 500, message: 'cache_control unsupported' })).toBe(false);
+    expect(isCacheControlRejection(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('AnthropicAdapter prompt-cache breakpoints on the wire', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearModelCapabilityCache();
+    __resetCacheControlSupport();
+    anthropicCreate.mockResolvedValue(GOOD_RESP);
+    anthropicStream.mockReturnValue({ finalMessage: jest.fn().mockResolvedValue(GOOD_RESP) });
+    anthropicRetrieve.mockResolvedValue({});
+  });
+
+  test('createCompletion sends breakpoints on tools, system and the last message', async () => {
+    await new AnthropicAdapter().createCompletion({
+      model: MODEL, apiKey: 'k', messages: MSGS, tools: TOOLS, temperature: 0,
+    });
+
+    const body = anthropicCreate.mock.calls[0][0];
+    expect(body.tools[body.tools.length - 1]).toHaveProperty('cache_control', EPHEMERAL);
+    expect(body.system).toEqual([
+      { type: 'text', text: 'You are helpful.', cache_control: EPHEMERAL },
+    ]);
+    expect(body.messages[body.messages.length - 1].content).toEqual([
+      { type: 'text', text: 'hi', cache_control: EPHEMERAL },
+    ]);
+  });
+
+  test('the streaming path gets the same breakpoints', async () => {
+    await new AnthropicAdapter().createStreamCompletion({
+      model: MODEL, apiKey: 'k', messages: MSGS, tools: TOOLS, temperature: 0,
+    });
+
+    const body = anthropicStream.mock.calls[0][0];
+    expect(body.tools[body.tools.length - 1]).toHaveProperty('cache_control', EPHEMERAL);
+    expect(body.system[0]).toHaveProperty('cache_control', EPHEMERAL);
+  });
+
+  test('an endpoint that rejects cache_control degrades instead of failing, once per endpoint', async () => {
+    const err = Object.assign(new Error('Unsupported field: cache_control'), { status: 400 });
+    anthropicCreate.mockRejectedValueOnce(err).mockResolvedValue(GOOD_RESP);
+
+    const proxied: Model = { ...MODEL, provider: 'anthropic', baseUrl: 'https://proxy.example/v1' } as Model;
+    const result = await new AnthropicAdapter().createCompletion({
+      model: proxied, apiKey: 'k', messages: MSGS, tools: TOOLS, temperature: 0,
+    });
+
+    expect(result.completion).toBeDefined();
+    expect(anthropicCreate).toHaveBeenCalledTimes(2);
+    // The retry drops the markers entirely — system falls back to a plain string.
+    const retry = anthropicCreate.mock.calls[1][0];
+    expect(retry.system).toBe('You are helpful.');
+    expect(retry.tools.every((t: object) => !('cache_control' in t))).toBe(true);
+
+    // A later call to the SAME endpoint must not pay the failed probe again.
+    anthropicCreate.mockClear();
+    await new AnthropicAdapter().createCompletion({
+      model: proxied, apiKey: 'k', messages: MSGS, tools: TOOLS, temperature: 0,
+    });
+    expect(anthropicCreate).toHaveBeenCalledTimes(1);
+    expect(anthropicCreate.mock.calls[0][0].system).toBe('You are helpful.');
+  });
+
+  test('a different endpoint still gets breakpoints after another one opted out', async () => {
+    const err = Object.assign(new Error('Unsupported field: cache_control'), { status: 400 });
+    anthropicCreate.mockRejectedValueOnce(err).mockResolvedValue(GOOD_RESP);
+
+    await new AnthropicAdapter().createCompletion({
+      model: { ...MODEL, baseUrl: 'https://proxy.example/v1' } as Model,
+      apiKey: 'k', messages: MSGS, temperature: 0,
+    });
+
+    anthropicCreate.mockClear();
+    await new AnthropicAdapter().createCompletion({
+      model: MODEL, apiKey: 'k', messages: MSGS, temperature: 0,
+    });
+    expect(Array.isArray(anthropicCreate.mock.calls[0][0].system)).toBe(true);
+  });
+
+  test('an unrelated 400 propagates rather than being masked by a retry', async () => {
+    const err = Object.assign(new Error('credit balance is too low'), { status: 400 });
+    anthropicCreate.mockRejectedValue(err);
+
+    await expect(
+      new AnthropicAdapter().createCompletion({
+        model: MODEL, apiKey: 'k', messages: MSGS, temperature: 0,
+      })
+    ).rejects.toThrow('credit balance is too low');
+    expect(anthropicCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AnthropicAdapter usage mapping with cache buckets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearModelCapabilityCache();
+    __resetCacheControlSupport();
+    anthropicRetrieve.mockResolvedValue({});
+  });
+
+  test('prompt_tokens is the FULL input context and cached_tokens is the re-read', async () => {
+    anthropicCreate.mockResolvedValue({
+      ...GOOD_RESP,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation_input_tokens: 100,
+        cache_read_input_tokens: 900,
+      },
+    });
+
+    const { completion } = await new AnthropicAdapter().createCompletion({
+      model: MODEL, apiKey: 'k', messages: MSGS, temperature: 0,
+    });
+
+    // input_tokens alone (10) would badly under-report the context; the meter
+    // needs all three buckets, with the cheap re-read broken out separately.
+    expect(completion.usage?.prompt_tokens).toBe(1010);
+    expect(completion.usage?.completion_tokens).toBe(5);
+    expect(completion.usage?.total_tokens).toBe(1015);
+    expect(completion.usage?.prompt_tokens_details?.cached_tokens).toBe(900);
+  });
+
+  test('omits prompt_tokens_details when the endpoint reports no cache buckets at all', async () => {
+    anthropicCreate.mockResolvedValue(GOOD_RESP); // usage without cache fields
+
+    const { completion } = await new AnthropicAdapter().createCompletion({
+      model: MODEL, apiKey: 'k', messages: MSGS, temperature: 0,
+    });
+
+    // "doesn't report caching" must stay distinguishable from "0 cached".
+    expect(completion.usage?.prompt_tokens).toBe(10);
+    expect(completion.usage).not.toHaveProperty('prompt_tokens_details');
+  });
+
+  test('reports 0 cached when the endpoint does report buckets but nothing hit', async () => {
+    anthropicCreate.mockResolvedValue({
+      ...GOOD_RESP,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation_input_tokens: 10,
+        cache_read_input_tokens: 0,
+      },
+    });
+
+    const { completion } = await new AnthropicAdapter().createCompletion({
+      model: MODEL, apiKey: 'k', messages: MSGS, temperature: 0,
+    });
+
+    expect(completion.usage?.prompt_tokens_details?.cached_tokens).toBe(0);
+  });
+});

--- a/src/backend/services/model/adapters/anthropicAdapter.ts
+++ b/src/backend/services/model/adapters/anthropicAdapter.ts
@@ -16,6 +16,87 @@ const DEFAULT_MAX_TOKENS = 8192;
 const CAPABILITY_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const modelCapabilityCache = new Map<string, { supportsTemperature: boolean; expiresAt: number }>();
 
+// --- Prompt caching -------------------------------------------------------
+//
+// Unlike the OpenAI-compatible path, which gets an AUTOMATIC prefix cache (see
+// openaiAdapter's prompt_cache_key), the Anthropic Messages API caches nothing
+// unless the request marks explicit `cache_control` breakpoints. Before this,
+// every native-Anthropic turn re-read the entire prefix — tool block, system
+// prompt, whole history — at full input price, on every iteration of every
+// agentic loop. Cache reads bill at ~0.1x, so on a long tool-using run this is
+// the dominant line item.
+//
+// A request may carry at most 4 breakpoints; the render order is fixed at
+// `tools` -> `system` -> `messages`, so each breakpoint's entry covers
+// everything before it. We place three (see applyCacheBreakpoints), leaving one
+// slot spare for future use.
+const EPHEMERAL: Anthropic.CacheControlEphemeral = { type: 'ephemeral' };
+
+/**
+ * Content-block types that accept `cache_control`. A breakpoint anchors to the
+ * LAST block of this kind in a message; a message with none is skipped rather
+ * than risking a 400 on a block type that can't carry the marker.
+ */
+const CACHEABLE_BLOCK_TYPES = new Set(['text', 'image', 'tool_use', 'tool_result', 'document']);
+
+/**
+ * Endpoints (provider + baseURL) that rejected `cache_control` — an
+ * Anthropic-compatible proxy that doesn't implement prompt caching. Populated at
+ * runtime from a narrowly-matched 400, so the retry happens once per process per
+ * endpoint instead of on every call. Mirrors openaiAdapter's
+ * `rejectedPromptCacheKey`: a wrong guess costs one retried request, never a
+ * broken provider. In-process only; a restart costs at most one more retry.
+ */
+const rejectedCacheControl = new Set<string>();
+
+const endpointKey = (provider?: string, baseUrl?: string) => `${provider ?? 'anthropic'}|${baseUrl ?? ''}`;
+
+/** Test seam: forget which endpoints rejected `cache_control`. */
+export function __resetCacheControlSupport(): void {
+  rejectedCacheControl.clear();
+}
+
+/**
+ * True when a provider error is specifically "I don't know this field", naming
+ * `cache_control`. Deliberately narrow: a 400 for any OTHER reason must
+ * propagate unchanged rather than be masked by a silent retry.
+ */
+export function isCacheControlRejection(err: unknown): boolean {
+  const status = (err as { status?: number })?.status;
+  if (status !== 400 && status !== 422) return false;
+  const haystack = [
+    (err as { message?: string })?.message,
+    JSON.stringify((err as { error?: unknown })?.error ?? ''),
+  ]
+    .join(' ')
+    .toLowerCase();
+  if (!haystack.includes('cache_control')) return false;
+  return (
+    haystack.includes('unknown') ||
+    haystack.includes('unrecognized') ||
+    haystack.includes('unsupported') ||
+    haystack.includes('not supported') ||
+    haystack.includes('not allowed') ||
+    haystack.includes('extra') ||
+    haystack.includes('additional')
+  );
+}
+
+/**
+ * How many optional request features `complete()` can negotiate away
+ * (`cache_control`, `temperature`) — the retry bound for its attempt loop.
+ */
+const DROPPABLE_FEATURES = 2;
+
+/** True when a 400 is Anthropic telling us `temperature` is gone on this model. */
+function isTemperatureDeprecated(err: unknown): boolean {
+  return (
+    err instanceof Anthropic.BadRequestError &&
+    err.message.includes('temperature') &&
+    err.message.toLowerCase().includes('deprecated')
+  );
+}
+
 /** Clears the capability cache. Call in tests between cases. */
 export function clearModelCapabilityCache(): void {
   modelCapabilityCache.clear();
@@ -235,6 +316,106 @@ export function toAnthropicTools(
     }));
 }
 
+/**
+ * Return a copy of `message` with `cache_control` on its last cacheable content
+ * block, or null when there is nothing to anchor to (an empty turn — Anthropic
+ * rejects both an empty content array and an empty text block).
+ *
+ * A string `content` is promoted to a one-element block array, which is the only
+ * shape that can carry the marker.
+ */
+function withCacheControl(message: Anthropic.MessageParam): Anthropic.MessageParam | null {
+  const { content } = message;
+
+  if (typeof content === 'string') {
+    if (content.length === 0) return null;
+    return { ...message, content: [{ type: 'text', text: content, cache_control: EPHEMERAL }] };
+  }
+  if (!Array.isArray(content)) return null;
+
+  // Anchor to the last block that can carry the marker. Marking an earlier block
+  // simply caches a shorter prefix, which is still correct.
+  for (let i = content.length - 1; i >= 0; i--) {
+    const block = content[i];
+    if (!CACHEABLE_BLOCK_TYPES.has((block as { type?: string }).type ?? '')) continue;
+    const marked = { ...block, cache_control: EPHEMERAL } as Anthropic.ContentBlockParam;
+    return { ...message, content: [...content.slice(0, i), marked, ...content.slice(i + 1)] };
+  }
+  return null;
+}
+
+/**
+ * Mark the request's cacheable prefix with `cache_control` breakpoints. Pure —
+ * returns new objects and never mutates the inputs, so a retry can rebuild the
+ * request from the originals.
+ *
+ * Three breakpoints, in render order (`tools` -> `system` -> `messages`):
+ *
+ *  1. the last TOOL definition — so the (large) tool block keeps hitting even
+ *     when the system prompt changes. That is the common FLUJO case: a handoff
+ *     to another node re-renders the system prompt while the tool set is
+ *     unchanged, and without this slot the whole prefix would go cold.
+ *  2. the last SYSTEM block — covers tools + system together.
+ *  3. the last content block of the last MESSAGE — the write point that the
+ *     NEXT turn of the agentic loop reads back.
+ *
+ * Extra breakpoints are close to free: the spans are cumulative, so an unread
+ * inner breakpoint does not re-write the prefix it shares with an outer one.
+ *
+ * Two provider behaviours worth knowing, neither of which this can fix:
+ *  - The minimum cacheable prefix is model-dependent (512 tokens on the newest
+ *    models, up to 4096 on some older ones) and a shorter prefix silently does
+ *    not cache — no error, just `cache_creation_input_tokens: 0`. Marking
+ *    unconditionally is therefore safe; on a short prompt it is a no-op.
+ *  - A breakpoint walks back at most 20 content blocks looking for a warm
+ *    entry. A normal tool-loop iteration appends 2-5 messages, so breakpoint 3
+ *    is found again next turn; a single node visit that appends more than 20
+ *    messages before the next model call will miss it and re-write instead.
+ */
+export function applyCacheBreakpoints(input: {
+  system?: string;
+  messages: Anthropic.MessageParam[];
+  tools?: Anthropic.Tool[];
+}): {
+  system?: string | Anthropic.TextBlockParam[];
+  messages: Anthropic.MessageParam[];
+  tools?: Anthropic.Tool[];
+  /** How many breakpoints were actually placed (0-3). For logging and tests. */
+  breakpoints: number;
+} {
+  let breakpoints = 0;
+
+  let tools = input.tools;
+  if (tools && tools.length > 0) {
+    const last = tools[tools.length - 1];
+    tools = [...tools.slice(0, -1), { ...last, cache_control: EPHEMERAL }];
+    breakpoints++;
+  }
+
+  let system: string | Anthropic.TextBlockParam[] | undefined = input.system;
+  if (input.system) {
+    system = [{ type: 'text', text: input.system, cache_control: EPHEMERAL }];
+    breakpoints++;
+  }
+
+  let messages = input.messages;
+  if (messages.length > 0) {
+    const tailIndex = messages.length - 1;
+    const marked = withCacheControl(messages[tailIndex]);
+    if (marked) {
+      messages = [...messages.slice(0, tailIndex), marked];
+      breakpoints++;
+    }
+  }
+
+  return {
+    ...(system !== undefined ? { system } : {}),
+    messages,
+    ...(tools ? { tools } : {}),
+    breakpoints,
+  };
+}
+
 /** Map an Anthropic response back into an OpenAI-shaped ChatCompletion. */
 function toChatCompletion(
   fallbackModel: string,
@@ -257,6 +438,19 @@ function toChatCompletion(
       });
     }
   }
+
+  // Anthropic splits input into three buckets and `input_tokens` counts only the
+  // FRESH portion, so it under-reports the real context size once caching is on.
+  // Report the FULL input context as prompt_tokens (keeping the context meter
+  // accurate — identical semantics to mapSdkUsage and mapOpenAiUsage) and surface
+  // the cheap re-read separately under prompt_tokens_details.cached_tokens, which
+  // is the field mapOpenAiUsage and the prompt-cache metrics read. With no
+  // caching both buckets are 0, so this is a no-op for uncached endpoints.
+  const cacheCreation = resp.usage.cache_creation_input_tokens ?? 0;
+  const cacheRead = resp.usage.cache_read_input_tokens ?? 0;
+  const reportsCache =
+    resp.usage.cache_creation_input_tokens != null || resp.usage.cache_read_input_tokens != null;
+  const promptTokens = resp.usage.input_tokens + cacheCreation + cacheRead;
 
   const finishReason: OpenAI.Chat.Completions.ChatCompletion.Choice['finish_reason'] =
     resp.stop_reason === 'tool_use'
@@ -284,9 +478,13 @@ function toChatCompletion(
       },
     ],
     usage: {
-      prompt_tokens: resp.usage.input_tokens,
+      prompt_tokens: promptTokens,
       completion_tokens: resp.usage.output_tokens,
-      total_tokens: resp.usage.input_tokens + resp.usage.output_tokens,
+      total_tokens: promptTokens + resp.usage.output_tokens,
+      // Only when the provider actually reported cache buckets, so consumers can
+      // tell "0 cached" apart from "this endpoint doesn't cache at all" — the
+      // same contract mapOpenAiUsage documents.
+      ...(reportsCache ? { prompt_tokens_details: { cached_tokens: cacheRead } } : {}),
     },
   };
 }
@@ -298,15 +496,59 @@ function toChatCompletion(
  * back to OpenAI `tool_calls` so FLUJO's tool-execution loop drives them.
  */
 export class AnthropicAdapter implements CompletionAdapter {
-  async createCompletion({
-    model,
-    apiKey,
-    messages,
-    tools,
-    temperature,
-    maxTokens,
-    signal,
-  }: CompletionInput): Promise<CompletionResult> {
+  async createCompletion(input: CompletionInput): Promise<CompletionResult> {
+    return this.complete(input, 'createCompletion', (client, params, options) =>
+      client.messages.create(params, options)
+    );
+  }
+
+  /**
+   * Streaming variant of createCompletion: uses the Anthropic SDK's
+   * client.messages.stream() helper to open a native streaming connection,
+   * then collects the final assembled Message via stream.finalMessage().
+   *
+   * AUDIT NOTE (issue #274): As of the audit at baseSha
+   * 18dbcbbbf7223aba499f4bc8f5489e5a52010ef8 there was no streaming branch in
+   * this adapter. This method adds one proactively so that the same temperature
+   * guard and catch-and-retry applied to createCompletion cannot be bypassed by
+   * callers that prefer native SDK streaming.
+   *
+   * The interface contract is identical to createCompletion: callers receive a
+   * CompletionResult containing an OpenAI-shaped ChatCompletion. Both paths now
+   * share `complete()` below, so the parameter fallbacks cannot diverge between
+   * them — which was the whole point of adding this method.
+   */
+  async createStreamCompletion(input: CompletionInput): Promise<CompletionResult> {
+    return this.complete(input, 'createStreamCompletion', async (client, params, options) => {
+      const stream = client.messages.stream(
+        params as Parameters<typeof client.messages.stream>[0],
+        options
+      );
+      return stream.finalMessage();
+    });
+  }
+
+  /**
+   * The one request path, shared by the streaming and non-streaming entry points.
+   *
+   * Negotiates away two optional-but-valuable request features, each detected
+   * narrowly and each dropped at most once, so the loop cannot spin:
+   *   - `cache_control` breakpoints — absent from Anthropic-compatible proxies
+   *     that don't implement prompt caching. Disabled per (provider, baseURL) for
+   *     the rest of the process, since the answer never changes mid-run.
+   *   - `temperature` — rejected by adaptive-thinking models (claude-opus-4-7+)
+   *     that aren't yet on the static denylist. NOT remembered: the capability
+   *     cache and Models API lookup already handle that per model.
+   */
+  private async complete(
+    { model, apiKey, messages, tools, temperature, maxTokens, signal }: CompletionInput,
+    label: string,
+    send: (
+      client: Anthropic,
+      params: Anthropic.MessageCreateParamsNonStreaming,
+      options?: { signal: AbortSignal }
+    ) => Promise<Anthropic.Message>
+  ): Promise<CompletionResult> {
     const client = new Anthropic({
       apiKey,
       // Honour a custom base URL if one was configured; otherwise the SDK
@@ -324,128 +566,72 @@ export class AnthropicAdapter implements CompletionAdapter {
     // checks a short-lived cache, then queries the Anthropic Models API for
     // live capability data, and finally falls back to the static denylist.
     const includeTemperature = await anthropicModelSupportsTemperature(model.name, client);
-    const params: Anthropic.MessageCreateParamsNonStreaming = {
-      model: model.name,
-      max_tokens: maxTokens ?? DEFAULT_MAX_TOKENS,
-      ...(includeTemperature ? { temperature } : {}),
-      messages: anthropicMessages,
-      ...(system ? { system } : {}),
-      ...(anthropicTools ? { tools: anthropicTools } : {}),
+    const endpoint = endpointKey(model.provider, model.baseUrl);
+
+    // Each attempt builds its own body from the untouched translation output, so
+    // the params already handed to the SDK are never rewritten underneath it.
+    const build = (opts: { cache: boolean; temperature: boolean }) => {
+      const shaped = opts.cache
+        ? applyCacheBreakpoints({ system, messages: anthropicMessages, tools: anthropicTools })
+        : { system, messages: anthropicMessages, tools: anthropicTools, breakpoints: 0 };
+      const params: Anthropic.MessageCreateParamsNonStreaming = {
+        model: model.name,
+        max_tokens: maxTokens ?? DEFAULT_MAX_TOKENS,
+        ...(opts.temperature ? { temperature } : {}),
+        messages: shaped.messages,
+        ...(shaped.system ? { system: shaped.system } : {}),
+        ...(shaped.tools ? { tools: shaped.tools } : {}),
+      };
+      return { params, breakpoints: shaped.breakpoints };
     };
 
-    log.debug('createCompletion via Anthropic SDK', {
-      model: model.name,
-      toolCount: anthropicTools?.length || 0,
-      hasSystem: Boolean(system),
-    });
-
+    let useCache = !rejectedCacheControl.has(endpoint);
+    let useTemperature = includeTemperature;
     // The abort signal (Stop button) cancels the in-flight HTTP request.
-    let resp: Anthropic.Message;
-    try {
-      resp = await client.messages.create(params, signal ? { signal } : undefined);
-    } catch (err) {
-      // Some models (e.g. claude-opus-4-7+) reject `temperature` with a 400.
-      // When not yet covered by the static denylist, auto-retry without it.
-      if (
-        err instanceof Anthropic.BadRequestError &&
-        err.message.includes('temperature') &&
-        err.message.toLowerCase().includes('deprecated') &&
-        'temperature' in params
-      ) {
-        log.warn(
-          'Anthropic API rejected temperature for model; retrying without it. ' +
-            'Consider adding this model to TEMPERATURE_DEPRECATED_SUBSTRINGS.',
-          { model: model.name }
-        );
-        const paramsWithoutTemp = { ...params };
-        delete (paramsWithoutTemp as Partial<typeof paramsWithoutTemp>).temperature;
-        resp = await client.messages.create(paramsWithoutTemp, signal ? { signal } : undefined);
-      } else {
+    const options = signal ? { signal } : undefined;
+
+    // One attempt, plus at most one retry per droppable feature. Each retry
+    // clears the flag its own guard tests, so the loop cannot spin; the bound
+    // mirrors openaiResponsesAdapter's negotiation loop as a backstop.
+    for (let attempt = 0; attempt <= DROPPABLE_FEATURES; attempt++) {
+      const { params, breakpoints } = build({ cache: useCache, temperature: useTemperature });
+
+      log.debug(`${label} via Anthropic SDK`, {
+        model: model.name,
+        toolCount: anthropicTools?.length ?? 0,
+        hasSystem: Boolean(system),
+        cacheBreakpoints: breakpoints,
+      });
+
+      try {
+        return { completion: toChatCompletion(model.name, await send(client, params, options)) };
+      } catch (err) {
+        if (useCache && breakpoints > 0 && isCacheControlRejection(err)) {
+          rejectedCacheControl.add(endpoint);
+          log.warn(
+            'Endpoint rejected cache_control; disabling prompt-cache breakpoints for it and retrying. ' +
+              'Requests to this endpoint will be billed without the cached-input discount.',
+            { model: model.name, provider: model.provider, baseUrl: model.baseUrl }
+          );
+          useCache = false;
+          continue;
+        }
+        // Some models (e.g. claude-opus-4-7+) reject `temperature` with a 400.
+        // When not yet covered by the static denylist, auto-retry without it.
+        if (useTemperature && isTemperatureDeprecated(err)) {
+          log.warn(
+            'Anthropic API rejected temperature for model; retrying without it. ' +
+              'Consider adding this model to TEMPERATURE_DEPRECATED_SUBSTRINGS.',
+            { model: model.name }
+          );
+          useTemperature = false;
+          continue;
+        }
         throw err;
       }
     }
-    return { completion: toChatCompletion(model.name, resp) };
-  }
 
-  /**
-   * Streaming variant of createCompletion: uses the Anthropic SDK's
-   * client.messages.stream() helper to open a native streaming connection,
-   * then collects the final assembled Message via stream.finalMessage().
-   *
-   * AUDIT NOTE (issue #274): As of the audit at baseSha
-   * 18dbcbbbf7223aba499f4bc8f5489e5a52010ef8 there was no streaming branch in
-   * this adapter. This method adds one proactively so that the same temperature
-   * guard and catch-and-retry applied to createCompletion cannot be bypassed by
-   * callers that prefer native SDK streaming.
-   *
-   * The interface contract is identical to createCompletion: callers receive a
-   * CompletionResult containing an OpenAI-shaped ChatCompletion.
-   */
-  async createStreamCompletion({
-    model,
-    apiKey,
-    messages,
-    tools,
-    temperature,
-    maxTokens,
-    signal,
-  }: CompletionInput): Promise<CompletionResult> {
-    const client = new Anthropic({
-      apiKey,
-      ...(model.baseUrl ? { baseURL: model.baseUrl } : {}),
-      timeout: LLM_REQUEST_TIMEOUT_MS,
-    });
-
-    const { system, messages: anthropicMessages } = toAnthropicMessages(messages);
-    const anthropicTools = toAnthropicTools(tools);
-
-    // NOTE: anthropicModelSupportsTemperature is now async (changed by issue #275).
-    const includeTemperature = await anthropicModelSupportsTemperature(model.name, client);
-    const params: Anthropic.MessageCreateParamsNonStreaming = {
-      model: model.name,
-      max_tokens: maxTokens ?? DEFAULT_MAX_TOKENS,
-      ...(includeTemperature ? { temperature } : {}),
-      messages: anthropicMessages,
-      ...(system ? { system } : {}),
-      ...(anthropicTools ? { tools: anthropicTools } : {}),
-    };
-
-    log.debug('createStreamCompletion via Anthropic SDK', {
-      model: model.name,
-      toolCount: anthropicTools?.length ?? 0,
-      hasSystem: Boolean(system),
-    });
-
-    let resp: Anthropic.Message;
-    try {
-      const stream = client.messages.stream(
-        params as Parameters<typeof client.messages.stream>[0],
-        signal ? { signal } : undefined
-      );
-      resp = await stream.finalMessage();
-    } catch (err) {
-      if (
-        err instanceof Anthropic.BadRequestError &&
-        err.message.includes('temperature') &&
-        err.message.toLowerCase().includes('deprecated') &&
-        'temperature' in params
-      ) {
-        log.warn(
-          'Anthropic API (streaming) rejected temperature for model; retrying without it. ' +
-            'Consider adding this model to TEMPERATURE_DEPRECATED_SUBSTRINGS.',
-          { model: model.name }
-        );
-        const paramsWithoutTemp = { ...params };
-        delete (paramsWithoutTemp as Partial<typeof paramsWithoutTemp>).temperature;
-        const retryStream = client.messages.stream(
-          paramsWithoutTemp as Parameters<typeof client.messages.stream>[0],
-          signal ? { signal } : undefined
-        );
-        resp = await retryStream.finalMessage();
-      } else {
-        throw err;
-      }
-    }
-    return { completion: toChatCompletion(model.name, resp) };
+    // Only reachable if every attempt was consumed by a fresh rejection.
+    throw new Error('Anthropic API rejected every supported parameter combination');
   }
 }


### PR DESCRIPTION
## What

The Anthropic Messages API caches **nothing** unless the request marks explicit `cache_control` breakpoints — unlike the OpenAI-compatible path, which gets an automatic prefix cache (and which FLUJO already shard-routes with `prompt_cache_key`). The native adapter set none, so every turn on the **Anthropic (Native)** provider re-read the entire prefix — tool block, system prompt, whole history — at full input price, on every iteration of every agentic loop. Cache reads bill at ~0.1×, so on a long tool-using run that was the dominant line item.

Found while investigating whether reordering the system prompt / tool block / history could save tokens. The ordering itself turns out not to be controllable (the API fixes it at `tools` → `system` → `messages`), but the missing breakpoints were sitting right next to it.

## Breakpoints

Three, in the API's fixed render order — max is 4, so one slot is left spare:

1. **last tool definition** — so the large tool block keeps hitting even when the system prompt changes. That is the common FLUJO case: a handoff to another node re-renders the system prompt while the tool set is unchanged, and without this slot the whole prefix would go cold.
2. **last system block** — covers tools + system together.
3. **last content block of the last message** — the write point the next turn of the loop reads back.

`applyCacheBreakpoints` is pure, so a retry rebuilds the body from the untouched translation output.

## Reporting

Without this the saving would be invisible. `toChatCompletion` mapped `prompt_tokens` from `input_tokens` alone, which counts only the *fresh* bucket. It now reports the full input context (`input + cache_creation + cache_read`) and breaks the cheap re-read out under `prompt_tokens_details.cached_tokens` — the same contract `mapSdkUsage` and `mapOpenAiUsage` document, and the field the context meter and the prompt-cache metrics read. Uncached endpoints report both buckets as 0, so it is a no-op for them; the details block is omitted entirely when an endpoint reports no buckets, keeping "0 cached" distinguishable from "does not cache".

## Compatibility

An Anthropic-compatible proxy that rejects `cache_control` degrades instead of failing: a narrowly matched 400 disables breakpoints for that `(provider, baseURL)` for the rest of the process and retries once — mirroring `rejectedPromptCacheKey` in the OpenAI adapter. Any other 400 propagates untouched.

The streaming and non-streaming entry points now share one `complete()` request path, so the parameter fallbacks cannot diverge between them — which was the stated reason the streaming variant was added.

## Caveats (provider behaviour, not fixable here — documented in comments)

- The minimum cacheable prefix is model-dependent (512 tokens on the newest models, up to 4096 on some older ones) and a shorter prefix **silently** does not cache. Marking unconditionally is therefore safe; on a short prompt it is a no-op.
- A breakpoint walks back at most 20 content blocks looking for a warm entry. A normal tool-loop iteration appends 2–5 messages, so breakpoint 3 is found again next turn; a single node visit that appends more than 20 messages before the next model call will miss it and re-write instead.

## Testing

- New `__tests__/model/anthropicPromptCache.test.ts`: breakpoint placement, purity, tail anchoring to the last markable block, empty-turn skip, the rejection detector's narrowness, wire shape on both the streaming and non-streaming paths, per-endpoint opt-out (and that a *different* endpoint still gets breakpoints), unrelated-400 propagation, and all three usage-mapping cases.
- Targeted run: 5 suites / 71 tests green (incl. the existing `anthropicTemperature`, `adapterTranslate`, `maxTokens` suites).
- Full node suite: 2830 passed, 4 failed — `resourceHandler` and `transientRetry` fail identically on clean HEAD (pre-existing), and the two scheduler suites are timing flakes that pass in isolation. No new failures.
- `tsc --noEmit` clean for this file; eslint clean.

## Not verified

No live round-trip against the real Anthropic API — `cache_read_input_tokens` climbing on a second turn is the thing to watch. The one-line `prompt-cache` INFO log will show it once the in-flight prompt-cache-metrics work lands.

