### PR TITLE
Fix registry publish: decryptApiKey never stripped the encrypted: envelope

### DIFF
--- a/__tests__/encryption/apiKeyRoundTrip.test.ts
+++ b/__tests__/encryption/apiKeyRoundTrip.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression tests for the `encryptApiKey` / `decryptApiKey` round-trip.
+ *
+ * `encryptApiKey` wraps its output in an `encrypted:` envelope, but
+ * `decryptWithPassword` expects a bare `iv:ciphertext` pair and splits on ':'.
+ * `decryptApiKey` used to hand the enveloped value straight through, so the split
+ * produced THREE parts and decryption bailed out with "Invalid ciphertext format",
+ * returning null. Callers that store an encrypted value and later decrypt it
+ * as-is (the package-registry account service) therefore never got their token
+ * back: publishing failed with "Sign in to the package registry before
+ * publishing." even immediately after a successful login.
+ *
+ * Like the sibling encryption suites, these drive the REAL storage backend
+ * against a throwaway temp data dir (via FLUJO_DATA_DIR) so the round-trip
+ * exercises the real crypto path rather than a mock.
+ */
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+// The real crypto path runs PBKDF2 at 100k iterations, which is deliberately
+// slow; give generous headroom over the suite default.
+jest.setTimeout(60000);
+
+let tmpDir: string;
+
+type Encryption = typeof import('@/backend/services/model/encryption');
+
+// Storage resolves its data dir at module load, so re-import after setting
+// FLUJO_DATA_DIR.
+async function loadEncryption(): Promise<Encryption> {
+  jest.resetModules();
+  return import('@/backend/services/model/encryption');
+}
+
+function clearGlobalEncryptionState(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).__flujo_server_dek = undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).__flujo_encryption_sessions = undefined;
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'flujo-apikey-'));
+  process.env.FLUJO_DATA_DIR = tmpDir;
+  clearGlobalEncryptionState();
+});
+
+afterEach(async () => {
+  delete process.env.FLUJO_DATA_DIR;
+  clearGlobalEncryptionState();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('encryptApiKey / decryptApiKey round-trip', () => {
+  it('decrypts a value straight back from encryptApiKey (envelope included)', async () => {
+    const { encryptApiKey, decryptApiKey } = await loadEncryption();
+
+    const secret = 'eyJhbGciOiJIUzI1NiJ9.registry-access-token.signature';
+    const stored = await encryptApiKey(secret);
+
+    // Guard the precondition this regression is about: the stored form carries
+    // the envelope, so it contains more than one ':' separator.
+    expect(stored.startsWith('encrypted:')).toBe(true);
+
+    await expect(decryptApiKey(stored)).resolves.toBe(secret);
+  });
+
+  it('still decrypts a bare iv:ciphertext value (callers that strip the envelope themselves)', async () => {
+    const { encryptApiKey, decryptApiKey } = await loadEncryption();
+
+    const secret = 'sk-test-bare-ciphertext-path';
+    const stored = await encryptApiKey(secret);
+    const bare = stored.substring('encrypted:'.length);
+
+    await expect(decryptApiKey(bare)).resolves.toBe(secret);
+  });
+
+  it('round-trips a token containing colons', async () => {
+    const { encryptApiKey, decryptApiKey } = await loadEncryption();
+
+    // Colons inside the plaintext must not confuse the envelope handling.
+    const secret = 'scheme:opaque:value:with:colons';
+    const stored = await encryptApiKey(secret);
+
+    await expect(decryptApiKey(stored)).resolves.toBe(secret);
+  });
+
+  it('unwraps the encrypted_failed marker without attempting decryption', async () => {
+    const { decryptApiKey } = await loadEncryption();
+
+    await expect(decryptApiKey('encrypted_failed:plain-value')).resolves.toBe('plain-value');
+  });
+});

--- a/src/backend/services/model/encryption.ts
+++ b/src/backend/services/model/encryption.ts
@@ -120,9 +120,19 @@ export async function decryptApiKey(encryptedApiKey: string): Promise<string | n
       // Return the original value without the marker
       return encryptedApiKey.substring('encrypted_failed:'.length);
     }
-    
+
+    // Strip the `encrypted:` envelope that `encryptApiKey` adds. `decryptWithPassword`
+    // expects a bare `iv:ciphertext` pair and splits on ':', so leaving the prefix in
+    // place yields three parts and it bails out with "Invalid ciphertext format".
+    // Other call sites (resolveGlobalVars, /api/env) strip this themselves before
+    // decrypting; doing it here makes decryptApiKey the exact inverse of encryptApiKey
+    // for callers that hand over a stored value as-is.
+    const ciphertext = encryptedApiKey?.startsWith('encrypted:')
+      ? encryptedApiKey.substring('encrypted:'.length)
+      : encryptedApiKey;
+
     // Use the decryption utility from secure.ts
-    return await decryptWithPassword(encryptedApiKey);
+    return await decryptWithPassword(ciphertext);
   } catch (error) {
     log.warn('decryptApiKey: Failed to decrypt API key:', error);
     return null;

--- a/src/backend/services/registry/index.ts
+++ b/src/backend/services/registry/index.ts
@@ -107,8 +107,23 @@ function toStatus(account: StoredRegistryAccount): RegistryAccountStatus {
   };
 }
 
+/**
+ * Masked, browser-safe view of the stored account, verified against the real
+ * decryptability of the token (not just presence of the ciphertext string).
+ * `toStatus()`'s `hasToken` check alone can't tell a usable token from stale/
+ * undecryptable ciphertext (e.g. left over from an encryption-key change), which
+ * showed the account as "signed in" while `publish()` still threw
+ * `NotAuthenticatedError`.
+ */
 export async function getAccountStatus(): Promise<RegistryAccountStatus> {
-  return toStatus(await loadStored());
+  const account = await loadStored();
+  if (account.accessToken) {
+    const decrypted = await decryptApiKey(account.accessToken);
+    if (!decrypted) {
+      return toStatus({ ...account, accessToken: '' });
+    }
+  }
+  return toStatus(account);
 }
 
 /**
@@ -309,10 +324,16 @@ async function withAccessToken<T>(
   call: (token: string) => Promise<client.RegistryHttpResponse<T>>,
 ): Promise<client.RegistryHttpResponse<T>> {
   const account = await loadStored();
-  if (!account.accessToken) throw new NotAuthenticatedError();
+  if (!account.accessToken) {
+    log.warn('withAccessToken: no accessToken stored; treating as signed out.');
+    throw new NotAuthenticatedError();
+  }
 
   const accessToken = await decryptApiKey(account.accessToken);
-  if (!accessToken) throw new NotAuthenticatedError();
+  if (!accessToken) {
+    log.warn('withAccessToken: stored accessToken could not be decrypted; treating as signed out.');
+    throw new NotAuthenticatedError();
+  }
 
   let result = await call(accessToken);
   if (result.status !== 401) return result;


### PR DESCRIPTION
## Root cause

`encryptApiKey` returns `encrypted:<iv>:<ciphertext>`, but `decryptApiKey` passed that value straight to `decryptWithPassword`, which splits on `':'` and requires **exactly two** parts. The envelope makes three, so it logged `decryptWithPassword: Invalid ciphertext format` and returned `null` for every value produced by its own encrypt counterpart.

Every other call site (`resolveGlobalVars`, `/api/env`) strips the `encrypted:` prefix itself before decrypting. The package-registry account service is the only caller that hands a stored value over as-is — so registry publishing could **never** authenticate: `withAccessToken` got a `null` token and threw `NotAuthenticatedError`, surfacing as "Sign in to the package registry before publishing." even immediately after a successful OAuth login. Logging out and back in could not help, because the freshly-stored token was undecryptable by the same code path that wrote it.

## Changes

1. **`decryptApiKey` strips the `encrypted:` envelope** — making it the exact inverse of `encryptApiKey`. Values that arrive already stripped (the other call sites) are unaffected.
2. **`getAccountStatus` verifies the token really decrypts** before reporting `signedIn`. It previously checked only that the ciphertext *string was non-empty*, which is why the UI showed the account as signed-in and "Confirmed" while publishing rejected it — the visual half of the same bug.
3. **`withAccessToken` logs which branch fired** (no token stored vs. token present but undecryptable), so this class of failure is diagnosable instead of silent.
4. **Round-trip regression test** (`__tests__/encryption/apiKeyRoundTrip.test.ts`) covering the enveloped form, the bare `iv:ciphertext` form, plaintext containing colons, and the `encrypted_failed:` marker.

## Test plan

- [x] New round-trip suite passes (4/4); the two envelope cases **fail with `null` when the fix is reverted**, confirming it catches the regression.
- [x] Full `encryption|registry|model|security` sweep: 668 passed. The single failure (`__tests__/model/transientRetry.test.ts`) reproduces on the unmodified baseline — pre-existing and unrelated.
- [ ] Live check: publish a package and confirm it succeeds without re-authenticating.

## Note

Any secret written through `encryptApiKey` and later read back through `decryptApiKey` was affected. Today that is only the registry tokens, but the fix is at the shared helper, so it covers future callers too.