### PR TITLE
Let the package wizard re-import an exported manifest

### DIFF
--- a/__tests__/packages/importManifest.test.ts
+++ b/__tests__/packages/importManifest.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Re-importing an exported manifest back into the creation wizard: the draft
+ * must restore the selection/metadata/secret names, and drop (but report)
+ * entities that no longer exist on the host.
+ */
+import { packageToWizardDraft, parseImportedPackage } from '@/shared/types/package/package.import';
+import type { FlujoPackage } from '@/shared/types/package/package';
+
+const manifest = (): FlujoPackage => ({
+  schemaVersion: 1,
+  id: 'pkg-1',
+  name: 'Demo package',
+  version: '1.2.3',
+  description: 'a demo',
+  tags: ['demo', 'test'],
+  secrets: [
+    { name: 'MODEL_GPT_API_KEY', required: true },
+    { name: 'HOME_PATH', required: true },
+  ],
+  models: [
+    { id: 'model-1', name: 'gpt-4', displayName: 'GPT 4', apiKeyRef: { kind: 'secret', secret: 'MODEL_GPT_API_KEY' } },
+    { id: 'model-gone', name: 'old', displayName: 'Old model', apiKeyRef: { kind: 'none' } },
+  ],
+  mcpServers: [],
+  flows: [
+    { flow: { id: 'flow-1', name: 'Main', nodes: [], edges: [] } as never },
+    { flow: { id: 'flow-gone', name: 'Deleted', nodes: [], edges: [] } as never },
+  ],
+  plannedExecutions: [
+    {
+      id: 'pe-1',
+      name: 'Nightly',
+      enabled: false,
+      flowId: 'flow-1',
+      prompt: 'go',
+      trigger: { type: 'manual' },
+    } as never,
+  ],
+});
+
+const available = {
+  flowIds: ['flow-1', 'flow-other'],
+  modelIds: ['model-1'],
+  mcpServerNames: ['server-a'],
+  plannedExecutionIds: ['pe-1'],
+};
+
+describe('packageToWizardDraft', () => {
+  it('restores the selection, metadata and secret names', () => {
+    const draft = packageToWizardDraft(manifest(), available);
+
+    expect(draft.selection).toEqual({
+      flowIds: ['flow-1'],
+      modelIds: ['model-1'],
+      mcpServerNames: [],
+      plannedExecutionIds: ['pe-1'],
+    });
+    expect(draft.metadata).toEqual({
+      name: 'Demo package',
+      version: '1.2.3',
+      description: 'a demo',
+      tags: ['demo', 'test'],
+    });
+    expect(draft.secretNames).toEqual(['MODEL_GPT_API_KEY', 'HOME_PATH']);
+  });
+
+  it('reports entities that no longer exist instead of selecting them', () => {
+    const draft = packageToWizardDraft(manifest(), available);
+
+    expect(draft.missing).toEqual([
+      { type: 'flow', label: 'Deleted (flow-gone)' },
+      { type: 'model', label: 'Old model' },
+    ]);
+  });
+
+  it('handles a manifest with no optional collections', () => {
+    const bare: FlujoPackage = {
+      schemaVersion: 1,
+      id: 'pkg-2',
+      name: 'Bare',
+      version: '0.1.0',
+      secrets: [],
+      models: [],
+      mcpServers: [],
+      flows: [],
+      plannedExecutions: [],
+    };
+    const draft = packageToWizardDraft(bare, available);
+    expect(draft.selection.flowIds).toEqual([]);
+    expect(draft.metadata).toEqual({ name: 'Bare', version: '0.1.0', description: '', tags: [] });
+    expect(draft.missing).toEqual([]);
+  });
+});
+
+describe('parseImportedPackage', () => {
+  it('accepts an exported manifest', () => {
+    const result = parseImportedPackage(JSON.stringify(manifest()));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.package.name).toBe('Demo package');
+  });
+
+  it('rejects malformed JSON without throwing', () => {
+    const result = parseImportedPackage('{not json');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors[0]).toMatch(/Not valid JSON/);
+  });
+
+  it('rejects JSON that is not a package manifest', () => {
+    const result = parseImportedPackage(JSON.stringify({ hello: 'world' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/frontend/components/Packages/PackageWizard.tsx
+++ b/src/frontend/components/Packages/PackageWizard.tsx
@@ -34,6 +34,7 @@ import {
   useTheme,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
 import RegistryAccountSettings from '@/frontend/components/Settings/RegistryAccountSettings';
 import { flowService } from '@/frontend/services/flow';
 import { modelService } from '@/frontend/services/model';
@@ -50,6 +51,8 @@ import type {
 } from '@/frontend/services/packages';
 import type { SecretKind, SecretProposal } from '@/shared/types/package/secretProposal';
 import { buildManualProposal, SECRET_KINDS } from '@/shared/types/package/secretProposal';
+import { packageToWizardDraft, parseImportedPackage } from '@/shared/types/package/package.import';
+import type { WizardDraft } from '@/shared/types/package/package.import';
 import { createLogger } from '@/utils/logger';
 
 const log = createLogger('frontend/components/Packages/PackageWizard');
@@ -104,6 +107,10 @@ export default function PackageWizard({ open, onClose }: Props) {
   const [modelSearch, setModelSearch] = useState('');
   const [serverSearch, setServerSearch] = useState('');
   const [plannedSearch, setPlannedSearch] = useState('');
+
+  // Step 0 — re-import of a previously exported manifest.
+  const [importedDraft, setImportedDraft] = useState<WizardDraft | null>(null);
+  const [importErrors, setImportErrors] = useState<string[]>([]);
 
   // Step 1 — resolution result.
   const [resolving, setResolving] = useState(false);
@@ -210,6 +217,63 @@ export default function PackageWizard({ open, onClose }: Props) {
     });
   };
 
+  /**
+   * Re-import a previously exported manifest (.json): restores the selection,
+   * the metadata fields and which secrets were accepted, so iterating on a
+   * package doesn't mean re-walking every step. Secret VALUES are never in a
+   * manifest, so accepted rows are matched by NAME after the content scan
+   * re-runs (step 2 reports any that can't be recovered).
+   */
+  const importManifestFile = useCallback(
+    async (file: File) => {
+      setImportErrors([]);
+      let text: string;
+      try {
+        text = await file.text();
+      } catch (err) {
+        setImportErrors([err instanceof Error ? err.message : 'Failed to read the file']);
+        return;
+      }
+      const parsed = parseImportedPackage(text);
+      if (!parsed.ok) {
+        setImportedDraft(null);
+        setImportErrors(parsed.errors.slice(0, 8));
+        return;
+      }
+      const draft = packageToWizardDraft(parsed.package, {
+        flowIds: entities.flows.map((f) => f.id),
+        modelIds: entities.models.map((m) => m.id),
+        mcpServerNames: entities.mcpServers.map((s) => s.id),
+        plannedExecutionIds: entities.plannedExecutions.map((p) => p.id),
+      });
+      setSelectedFlows(new Set(draft.selection.flowIds));
+      setSelectedModels(new Set(draft.selection.modelIds));
+      setSelectedServers(new Set(draft.selection.mcpServerNames));
+      setSelectedPlanned(new Set(draft.selection.plannedExecutionIds));
+      setName(draft.metadata.name);
+      setVersion(draft.metadata.version);
+      setDescription(draft.metadata.description);
+      setTagsInput(draft.metadata.tags.join(', '));
+      // Anything derived from the old selection is stale.
+      setResolveResult(null);
+      setResolveError(null);
+      setContentProposals([]);
+      setDerivedOnce(false);
+      setDeriveError(null);
+      setDeriveWarnings([]);
+      setBuildResult(null);
+      setBuildError(null);
+      setPublishResult(null);
+      setImportedDraft(draft);
+      log.info('Imported package manifest into the wizard', {
+        name: draft.metadata.name,
+        version: draft.metadata.version,
+        missing: draft.missing.length,
+      });
+    },
+    [entities],
+  );
+
   const runResolve = useCallback(async () => {
     setResolving(true);
     setResolveError(null);
@@ -235,6 +299,11 @@ export default function PackageWizard({ open, onClose }: Props) {
    * (sending packaged content to that provider). Preserves the user's per-row
    * accept/rename choices across a re-scan.
    */
+  const importedSecretNames = useMemo(
+    () => (importedDraft ? new Set(importedDraft.secretNames) : null),
+    [importedDraft],
+  );
+
   const runDerive = useCallback(
     async (modelIdentifier?: string) => {
       setDeriving(true);
@@ -251,10 +320,17 @@ export default function PackageWizard({ open, onClose }: Props) {
           const acceptedById = new Map(prev.map((p) => [p.id, p.accepted]));
           const nameById = new Map(prev.map((p) => [p.id, p.suggestedSecretName]));
           const manual = prev.filter((p) => p.source === 'manual');
+          // After a manifest re-import, reproduce the imported package's choices:
+          // accept exactly the rows whose suggested name it declared.
+          const imported = importedSecretNames;
           const scanned = res.proposals.map((p) => ({
             ...p,
-            // Default-accept everything except low-confidence noise (issue #208).
-            accepted: acceptedById.has(p.id) ? acceptedById.get(p.id) : p.confidence !== 'low',
+            accepted: acceptedById.has(p.id)
+              ? acceptedById.get(p.id)
+              : imported
+                ? imported.has(p.suggestedSecretName)
+                : // Default-accept everything except low-confidence noise (issue #208).
+                  p.confidence !== 'low',
             suggestedSecretName: nameById.get(p.id) ?? p.suggestedSecretName,
           }));
           const scannedIds = new Set(scanned.map((p) => p.id));
@@ -268,7 +344,7 @@ export default function PackageWizard({ open, onClose }: Props) {
         setDerivedOnce(true);
       }
     },
-    [selection, scanEntropy, scanRepoSlug],
+    [selection, scanEntropy, scanRepoSlug, importedSecretNames],
   );
 
   const toggleProposalGroup = (ids: string[]) =>
@@ -390,6 +466,18 @@ export default function PackageWizard({ open, onClose }: Props) {
         .includes(q),
     );
   }, [groupedProposals, proposalFilter]);
+
+  // Secrets the imported manifest declared that neither the entity-secret step
+  // nor the re-run content scan produced — their VALUES were redacted on export,
+  // so they can only be restored by re-adding them manually (issue: re-import).
+  const unrecoveredSecretNames = useMemo(() => {
+    if (!importedDraft || !derivedOnce) return [];
+    const known = new Set<string>([
+      ...(resolveResult?.secrets ?? []).map((s) => s.name),
+      ...contentProposals.map((p) => p.suggestedSecretName),
+    ]);
+    return importedDraft.secretNames.filter((n) => !known.has(n));
+  }, [importedDraft, derivedOnce, resolveResult, contentProposals]);
 
   const kindCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -570,6 +658,56 @@ export default function PackageWizard({ open, onClose }: Props) {
               Pick the entities to include. Dependencies (subflows, referenced models and
               MCP servers, planned-execution flows) are pulled in automatically in the next step.
             </Typography>
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+              <Button component="label" variant="outlined" startIcon={<UploadFileIcon />}>
+                Import manifest (.json)
+                <input
+                  type="file"
+                  accept="application/json,.json"
+                  hidden
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    // Reset the input so re-picking the same file fires onChange again.
+                    e.target.value = '';
+                    if (file) void importManifestFile(file);
+                  }}
+                />
+              </Button>
+              <Typography variant="caption" color="text.secondary">
+                Restores the selection, metadata and accepted secrets from a package you
+                exported earlier.
+              </Typography>
+            </Stack>
+            {importErrors.length > 0 && (
+              <Alert severity="error" onClose={() => setImportErrors([])}>
+                <AlertTitle>Could not import that file</AlertTitle>
+                {importErrors.map((e, i) => (
+                  <div key={i}>{e}</div>
+                ))}
+              </Alert>
+            )}
+            {importedDraft && (
+              <Alert severity={importedDraft.missing.length > 0 ? 'warning' : 'success'}>
+                <AlertTitle>
+                  Imported “{importedDraft.metadata.name}” v{importedDraft.metadata.version}
+                </AlertTitle>
+                Restored {importedDraft.selection.flowIds.length} flow(s),{' '}
+                {importedDraft.selection.modelIds.length} model(s),{' '}
+                {importedDraft.selection.mcpServerNames.length} MCP server(s),{' '}
+                {importedDraft.selection.plannedExecutionIds.length} planned execution(s) and{' '}
+                {importedDraft.secretNames.length} secret name(s).
+                {importedDraft.missing.length > 0 && (
+                  <Box sx={{ mt: 1 }}>
+                    No longer on this host (left unselected):
+                    {importedDraft.missing.map((m, i) => (
+                      <div key={i}>
+                        {m.type}: {m.label}
+                      </div>
+                    ))}
+                  </Box>
+                )}
+              </Alert>
+            )}
             <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
               {renderList('Flows', entities.flows, selectedFlows, toggle(setSelectedFlows), flowSearch, setFlowSearch)}
               {renderList('Models', entities.models, selectedModels, toggle(setSelectedModels), modelSearch, setModelSearch)}
@@ -788,6 +926,15 @@ export default function PackageWizard({ open, onClose }: Props) {
                   ))}
                 </List>
               </>
+            )}
+
+            {unrecoveredSecretNames.length > 0 && (
+              <Alert severity="warning">
+                <AlertTitle>Secrets from the imported manifest that need re-adding</AlertTitle>
+                A manifest never carries secret values, so these declarations could not be
+                matched to anything in the current content — re-add them below if they still
+                apply: {unrecoveredSecretNames.join(', ')}.
+              </Alert>
             )}
 
             {deriveWarnings.length > 0 && (

--- a/src/shared/types/package/index.ts
+++ b/src/shared/types/package/index.ts
@@ -13,3 +13,4 @@ export * from './installOrigin';
 export * from './package';
 export * from './package.schema';
 export * from './package.serialize';
+export * from './package.import';

--- a/src/shared/types/package/package.import.ts
+++ b/src/shared/types/package/package.import.ts
@@ -1,0 +1,132 @@
+/**
+ * Re-import an exported package manifest back into the creation wizard.
+ *
+ * Exporting is lossy in exactly one direction: secret VALUES are redacted (by
+ * design). Everything the wizard needs to reconstruct a run is still in the
+ * manifest — the packaged flows/models/servers/planned executions carry their
+ * original host ids/names, and the metadata step's fields are top-level. So a
+ * manifest can restore the selection, the metadata and WHICH secrets were
+ * accepted (by name), which is what makes iterating on a package practical:
+ * export → tweak → re-import instead of re-walking every step by hand.
+ *
+ * Pure/isomorphic like the rest of `src/shared/types/package/` — the wizard
+ * imports this directly in the browser.
+ */
+import type { FlujoPackage } from './package';
+import { validatePackage } from './package.serialize';
+
+/** The entity ids/names that currently exist on this host. */
+export interface AvailableEntities {
+  flowIds: readonly string[];
+  modelIds: readonly string[];
+  mcpServerNames: readonly string[];
+  plannedExecutionIds: readonly string[];
+}
+
+/** A wizard selection restored from a manifest. */
+export interface ImportedSelection {
+  flowIds: string[];
+  modelIds: string[];
+  mcpServerNames: string[];
+  plannedExecutionIds: string[];
+}
+
+/** Metadata-step values restored from a manifest. */
+export interface ImportedMetadata {
+  name: string;
+  version: string;
+  description: string;
+  tags: string[];
+}
+
+export interface WizardDraft {
+  selection: ImportedSelection;
+  metadata: ImportedMetadata;
+  /**
+   * Names of every secret the manifest declared. The wizard re-runs the content
+   * scan against live entities and auto-accepts the rows whose suggested name
+   * appears here, reproducing the previous export's redaction choices.
+   */
+  secretNames: string[];
+  /** Entities the manifest referenced that no longer exist on this host. */
+  missing: Array<{ type: 'flow' | 'model' | 'mcpServer' | 'plannedExecution'; label: string }>;
+}
+
+/**
+ * Map a validated manifest to a wizard draft, keeping only entities that still
+ * exist locally (the wizard can only select live entities). Anything gone is
+ * reported in `missing` so the user learns why the selection shrank instead of
+ * silently exporting less than last time.
+ */
+export function packageToWizardDraft(pkg: FlujoPackage, available: AvailableEntities): WizardDraft {
+  const liveFlows = new Set(available.flowIds);
+  const liveModels = new Set(available.modelIds);
+  const liveServers = new Set(available.mcpServerNames);
+  const livePlanned = new Set(available.plannedExecutionIds);
+
+  const missing: WizardDraft['missing'] = [];
+  const selection: ImportedSelection = {
+    flowIds: [],
+    modelIds: [],
+    mcpServerNames: [],
+    plannedExecutionIds: [],
+  };
+
+  for (const entry of pkg.flows ?? []) {
+    const id = entry?.flow?.id;
+    if (!id) continue;
+    if (liveFlows.has(id)) selection.flowIds.push(id);
+    else missing.push({ type: 'flow', label: entry.flow?.name ? `${entry.flow.name} (${id})` : id });
+  }
+  for (const model of pkg.models ?? []) {
+    if (!model?.id) continue;
+    if (liveModels.has(model.id)) selection.modelIds.push(model.id);
+    else missing.push({ type: 'model', label: model.displayName || model.name || model.id });
+  }
+  for (const server of pkg.mcpServers ?? []) {
+    if (!server?.name) continue;
+    if (liveServers.has(server.name)) selection.mcpServerNames.push(server.name);
+    else missing.push({ type: 'mcpServer', label: server.name });
+  }
+  for (const pe of pkg.plannedExecutions ?? []) {
+    const id = (pe as { id?: string })?.id;
+    if (!id) continue;
+    if (livePlanned.has(id)) selection.plannedExecutionIds.push(id);
+    else missing.push({ type: 'plannedExecution', label: (pe as { name?: string }).name || id });
+  }
+
+  return {
+    selection,
+    metadata: {
+      name: pkg.name ?? '',
+      version: pkg.version ?? '',
+      description: pkg.description ?? '',
+      tags: pkg.tags ? [...pkg.tags] : [],
+    },
+    secretNames: (pkg.secrets ?? []).map((s) => s.name).filter(Boolean),
+    missing,
+  };
+}
+
+export type ParseImportedPackageResult =
+  | { ok: true; package: FlujoPackage }
+  | { ok: false; errors: string[] };
+
+/**
+ * Parse + validate an uploaded manifest file's text. Never throws: bad JSON and
+ * schema violations both come back as human-readable errors for the wizard to
+ * render.
+ */
+export function parseImportedPackage(text: string): ParseImportedPackageResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    return { ok: false, errors: [`Not valid JSON: ${err instanceof Error ? err.message : String(err)}`] };
+  }
+  const result = validatePackage(raw);
+  if (!result.success || !result.data) {
+    return { ok: false, errors: result.errors ?? ['Not a valid FLUJO package manifest'] };
+  }
+  return { ok: true, package: result.data };
+}


### PR DESCRIPTION
## Why

Testing the packages wizard meant redoing every step for each run — selecting entities, triaging secrets, retyping name/version/description/tags — because there was no way to load a manifest back in.

## What

- **Step 1 → "Import manifest (.json)"**: upload a package you exported earlier. It restores the selection (flows / models / MCP servers / planned executions), the metadata step, and which secrets were accepted, then invalidates any stale resolve/derive/build state.
- Entities in the manifest that no longer exist on this host are left unselected and listed in the import summary, so a shrunken export is never silent.
- Secret **values** are redacted on export by design. Accepted rows are therefore reproduced by *name*: the content scan re-runs and auto-accepts the rows whose suggested name the manifest declared. Anything it can't match (e.g. a manually added secret) is listed in the secret-review step as "needs re-adding".
- Mapping logic is a pure, isomorphic helper (`src/shared/types/package/package.import.ts`): `parseImportedPackage` (never throws — bad JSON and schema violations both come back as messages) + `packageToWizardDraft`.

## Tests

`__tests__/packages/importManifest.test.ts` — 6 new tests (selection/metadata/secret-name restore, missing-entity reporting, bare manifest, and the three parse paths). All 9 package suites pass (110 tests); `tsc --noEmit` and eslint are clean for the touched files.

Note: unrelated, pre-existing `tsc` errors live in `__tests__/mcp/filesystemApp.test.ts`, `__tests__/meta/testMatchCoverage.test.ts` and `__tests__/model/anthropicPromptCache.test.ts`. Also, jest's `<rootDir>/…` globs don't match inside a `.claude/worktrees/…` path, so suites here have to be run with an explicit `--testMatch`.

## Not done

Installing a package straight from a local manifest file still isn't possible (`/api/packages/install` only accepts `source: 'registry'`). Say the word if that's the round-trip you actually wanted and I'll add it.