### PR TITLE
Simplify MCP flow authoring and add draft tool

### DIFF
--- a/__tests__/mcp/flowAuthoringTools.test.ts
+++ b/__tests__/mcp/flowAuthoringTools.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for the flow-authoring tools on the built-in FLUJO MCP server (#14 follow-up):
- * list_flow_building_blocks / validate_flow_spec / create_flow. External agents author
+ * list_flow_building_blocks / guide / validate / draft / create. External agents author
  * the semantic FlowSpec; these tools compile, validate, and (create_flow only, gated on
  * zero errors) save — no raw ReactFlow JSON in the contract.
  */
@@ -39,6 +39,7 @@ import {
   authoringCallTool,
 } from '@/backend/services/mcp/flowAuthoringTools';
 import { FLOWSPEC_DOC } from '@/utils/shared/flowSpecDoc';
+import { SIMPLE_FLOW_SPEC_SCHEMA } from '@/utils/shared/simpleFlowSpec';
 
 const goodSpec = {
   name: 'agent_made_flow',
@@ -51,6 +52,13 @@ const goodSpec = {
     { from: 's', to: 'p' },
     { from: 'p', to: 'f' },
   ],
+};
+
+const simpleSpec = {
+  name: 'guided_flow',
+  goal: 'Do the work',
+  model: 'worker',
+  steps: [{ id: 'work', task: 'Do it with the configured tool', tools: ['srv/tool_a'] }],
 };
 
 function textOf(result: { content: Array<{ type: string }> }): string {
@@ -80,20 +88,37 @@ beforeEach(() => {
 });
 
 describe('tool definitions', () => {
-  it('exposes exactly the three authoring tools, recognized by isAuthoringTool', () => {
+  it('exposes the authoring tools, recognized by isAuthoringTool', () => {
     const defs = authoringToolDefinitions();
     expect(defs.map((t) => t.name)).toEqual([...AUTHORING_TOOL_NAMES]);
     for (const name of AUTHORING_TOOL_NAMES) expect(isAuthoringTool(name)).toBe(true);
     expect(isAuthoringTool('some_flow_tool')).toBe(false);
   });
 
-  it('embeds the canonical FlowSpec documentation in the spec-taking tools', () => {
+  it('uses the compact schema instead of embedding the advanced guide in every tool', () => {
     const defs = authoringToolDefinitions();
     const create = defs.find((t) => t.name === 'create_flow')!;
     const validate = defs.find((t) => t.name === 'validate_flow_spec')!;
-    expect(create.description).toContain(FLOWSPEC_DOC);
-    expect(validate.description).toContain(FLOWSPEC_DOC);
+    const draft = defs.find((t) => t.name === 'draft_flow')!;
+    expect(create.description).not.toContain(FLOWSPEC_DOC);
+    expect(validate.description).not.toContain(FLOWSPEC_DOC);
+    expect(draft.description).not.toContain(FLOWSPEC_DOC);
+    expect(create.description!.length).toBeLessThan(400);
     expect(create.inputSchema).toEqual(expect.objectContaining({ required: ['spec'] }));
+    expect(JSON.stringify(create.inputSchema)).toContain(JSON.stringify(SIMPLE_FLOW_SPEC_SCHEMA.required));
+  });
+});
+
+describe('get_flow_authoring_guide', () => {
+  it('returns the compact schema by default and the full guide only on demand', async () => {
+    const simple = payload(await authoringCallTool('get_flow_authoring_guide', {}));
+    expect(simple.profile).toBe('simple');
+    expect(simple.schema).toEqual(SIMPLE_FLOW_SPEC_SCHEMA);
+    expect(simple.guide.join(' ')).not.toContain(FLOWSPEC_DOC);
+
+    const advanced = payload(await authoringCallTool('get_flow_authoring_guide', { profile: 'advanced' }));
+    expect(advanced.profile).toBe('advanced');
+    expect(advanced.guide).toBe(FLOWSPEC_DOC);
   });
 });
 
@@ -141,11 +166,31 @@ describe('validate_flow_spec', () => {
     expect(body.validation.errorCount).toBe(0);
   });
 
+  it('defaults a guided steps spec to the simple profile', async () => {
+    const body = payload(await authoringCallTool('validate_flow_spec', { spec: simpleSpec }));
+    expect(body.profile).toBe('simple');
+    expect(body.validation.errorCount).toBe(0);
+    expect(body.flowName).toBe('guided_flow');
+  });
+
   it('errors helpfully when spec is missing or unparseable', async () => {
     const missing = await authoringCallTool('validate_flow_spec', {});
     expect(missing.isError).toBe(true);
     const garbled = await authoringCallTool('validate_flow_spec', { spec: '{not json' });
     expect(garbled.isError).toBe(true);
+  });
+});
+
+describe('draft_flow', () => {
+  it('returns the complete bundle without saving', async () => {
+    const result = await authoringCallTool('draft_flow', { spec: simpleSpec });
+    expect(result.isError).toBeUndefined();
+    const body = payload(result);
+    expect(body.saved).toBe(false);
+    expect(body.rootFlowId).toBe(body.flow.id);
+    expect(body.flows).toHaveLength(1);
+    expect(body.flow.nodes.some((node: { type: string }) => node.type === 'process')).toBe(true);
+    expect(saveFlowMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/backend/services/flow/compileFlow.ts
+++ b/src/backend/services/flow/compileFlow.ts
@@ -24,6 +24,7 @@ import { createLogger } from '@/utils/logger';
 import { Flow } from '@/shared/types/flow';
 import { flowService } from '@/backend/services/flow';
 import { compileFlowSpec, FlowSpec } from '@/utils/shared/flowSpecCompiler';
+import { compileSimpleFlowSpec, type SimpleFlowSpec } from '@/utils/shared/simpleFlowSpec';
 import { validateFlow, FlowValidationResult } from '@/utils/shared/flowValidation';
 import { gatherGenerationContext, mergeIssues } from './generationContext';
 
@@ -53,7 +54,13 @@ export type CompileSpecResult = CompileSpecSuccess | CompileSpecFailure;
 
 export async function compileSpec(
   spec: unknown,
-  options: { save?: boolean; updateFlowId?: string; keepPills?: boolean } = {}
+  options: {
+    save?: boolean;
+    updateFlowId?: string;
+    keepPills?: boolean;
+    /** Defaults to advanced for REST/backward compatibility. */
+    profile?: 'simple' | 'advanced';
+  } = {}
 ): Promise<CompileSpecResult> {
   if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
     return { success: false, error: 'The spec must be a JSON object (a FlowSpec)', statusCode: 400 };
@@ -71,7 +78,9 @@ export async function compileSpec(
     // subflow reference to the flow being replaced would recurse into itself.
     compileContext = { ...compileContext, flows: flows.filter((f) => f.id !== options.updateFlowId) };
   }
-  const compiled = compileFlowSpec(spec as FlowSpec, compileContext, { keepPills: options.keepPills });
+  const compiled = options.profile === 'simple'
+    ? compileSimpleFlowSpec(spec as SimpleFlowSpec, compileContext, { keepPills: options.keepPills })
+    : compileFlowSpec(spec as FlowSpec, compileContext, { keepPills: options.keepPills });
 
   if (!compiled.flow) {
     return {

--- a/src/backend/services/mcp/flowAuthoringTools.ts
+++ b/src/backend/services/mcp/flowAuthoringTools.ts
@@ -25,6 +25,7 @@
 import { createLogger } from '@/utils/logger';
 import type { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { FLOWSPEC_DOC } from '@/utils/shared/flowSpecDoc';
+import { SIMPLE_FLOW_SPEC_SCHEMA } from '@/utils/shared/simpleFlowSpec';
 import { compileSpec } from '@/backend/services/flow/compileFlow';
 import { gatherGenerationContext } from '@/backend/services/flow/generationContext';
 import { searchRegistry, installRegistryServer, installBestForCapability } from '@/backend/services/mcp/registryInstall';
@@ -36,7 +37,9 @@ const log = createLogger('backend/services/mcp/flowAuthoringTools');
 
 export const AUTHORING_TOOL_NAMES = [
   'list_flow_building_blocks',
+  'get_flow_authoring_guide',
   'validate_flow_spec',
+  'draft_flow',
   'create_flow',
   'search_mcp_marketplace',
   'install_mcp_server',
@@ -47,14 +50,28 @@ export function isAuthoringTool(name: string): boolean {
   return (AUTHORING_TOOL_NAMES as readonly string[]).includes(name);
 }
 
-/** JSON Schema for the spec-taking tools: one object argument. */
+/** JSON Schema for guided authoring, with the legacy advanced shape retained. */
 function specInputSchema(): Tool['inputSchema'] {
   return {
     type: 'object',
+    additionalProperties: false,
     properties: {
       spec: {
-        type: 'object',
-        description: 'The FlowSpec object (see the tool description for the format).',
+        oneOf: [
+          SIMPLE_FLOW_SPEC_SCHEMA,
+          {
+            type: 'object',
+            description:
+              'Legacy advanced FlowSpec with nodes and edges. Pass profile="advanced"; fetch its contract with get_flow_authoring_guide.',
+          },
+        ],
+        description: 'A guided SimpleFlowSpec by default, or a legacy advanced FlowSpec.',
+      },
+      profile: {
+        type: 'string',
+        enum: ['simple', 'advanced'],
+        description:
+          'Authoring profile. Defaults to simple; legacy specs containing nodes+edges are auto-detected as advanced.',
       },
       keepPills: {
         type: 'boolean',
@@ -71,17 +88,40 @@ export function authoringToolDefinitions(): Tool[] {
     {
       name: 'list_flow_building_blocks',
       description:
-        'List everything a FlowSpec may reference in this FLUJO instance: configured models (bind to process steps), MCP servers and their tools (attach via "servers"), and existing flows (usable as subflow targets). Call this before authoring a spec.',
+        'List models, MCP server/tool references, and existing flows available to a new flow.',
       inputSchema: { type: 'object', properties: {} },
     },
     {
+      name: 'get_flow_authoring_guide',
+      description:
+        'Fetch the flow-authoring contract only when needed. The simple guide is compact; the advanced guide contains the complete FlowSpec reference.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          profile: {
+            type: 'string',
+            enum: ['simple', 'advanced'],
+            description: 'Guide to return. Defaults to simple.',
+          },
+        },
+      },
+    },
+    {
       name: 'validate_flow_spec',
-      description: `Compile and validate a FlowSpec WITHOUT saving. Returns the compiled flow's validation result (errors block saving; warnings are advisory) so you can iterate until clean, then call create_flow.\n\n${FLOWSPEC_DOC}`,
+      description:
+        'Compile and validate a guided flow without saving. Returns a compact summary and issues. Use draft_flow when the caller needs the complete unsaved draft.',
+      inputSchema: specInputSchema(),
+    },
+    {
+      name: 'draft_flow',
+      description:
+        'Compile and validate a flow WITHOUT saving and return the complete draft bundle for review or opening in the Flow Builder.',
       inputSchema: specInputSchema(),
     },
     {
       name: 'create_flow',
-      description: `Create a new FLUJO flow from a FlowSpec. The spec is compiled deterministically (layout, ids, and wiring are generated for you) and saved ONLY when validation finds zero errors — otherwise the issues are returned to fix. Use list_flow_building_blocks first to see the models, MCP servers/tools, and existing flows you may reference.\n\n${FLOWSPEC_DOC}`,
+      description:
+        'Compile, validate, and save a guided flow. Saving occurs only when validation has no errors. Use list_flow_building_blocks for valid references.',
       inputSchema: specInputSchema(),
     },
     {
@@ -164,6 +204,25 @@ export async function authoringCallTool(
     if (toolName === 'list_flow_building_blocks') {
       const context = await gatherGenerationContext();
       return textResult(context.blocks);
+    }
+
+    if (toolName === 'get_flow_authoring_guide') {
+      const profile = args?.profile === 'advanced' ? 'advanced' : 'simple';
+      if (profile === 'advanced') {
+        return textResult({ profile, guide: FLOWSPEC_DOC });
+      }
+      return textResult({
+        profile,
+        schema: SIMPLE_FLOW_SPEC_SCHEMA,
+        guide: [
+          'Set name, goal, and one or more ordered steps.',
+          'Each step needs id and task. model overrides the top-level default.',
+          'Tools use server/tool references from list_flow_building_blocks.',
+          'Set flow on a step to run an existing flow instead of a model.',
+          'Omit routes for a linear flow. Routes are only for branches; omit when for the fallback.',
+          'Start, Finish, layout, data handoff, and ordinary defaults are inferred.',
+        ],
+      });
     }
 
     if (toolName === 'search_mcp_marketplace') {
@@ -265,13 +324,27 @@ export async function authoringCallTool(
       );
     }
 
-    if (toolName === 'validate_flow_spec' || toolName === 'create_flow') {
+    if (toolName === 'validate_flow_spec' || toolName === 'draft_flow' || toolName === 'create_flow') {
       const spec = extractSpec(args);
       if (!spec) {
-        return textResult({ error: 'Provide a "spec" argument: a FlowSpec object (or a JSON string of one).' }, true);
+        return textResult({ error: 'Provide a "spec" argument: a SimpleFlowSpec object (or JSON string).' }, true);
       }
+      const record = spec && typeof spec === 'object' && !Array.isArray(spec)
+        ? spec as Record<string, unknown>
+        : {};
+      const profile = args.profile === 'advanced'
+        ? 'advanced'
+        : args.profile === 'simple'
+          ? 'simple'
+          : Array.isArray(record.nodes) && Array.isArray(record.edges)
+            ? 'advanced'
+            : 'simple';
       const keepPills = args.keepPills === true;
-      const result = await compileSpec(spec, { save: toolName === 'create_flow', keepPills });
+      const result = await compileSpec(spec, {
+        save: toolName === 'create_flow',
+        keepPills,
+        profile,
+      });
       if (!result.success) {
         return textResult({ error: result.error, issues: result.issues ?? [] }, true);
       }
@@ -280,12 +353,21 @@ export async function authoringCallTool(
       const bundleCount = result.flows.length;
       const subflowNote = bundleCount > 1 ? ` (plus ${bundleCount - 1} nested subflow flow(s))` : '';
       const summary = {
+        profile,
         flowId: result.flow.id,
         flowName: result.flow.name,
         nodeCount: result.flow.nodes.length,
         edgeCount: result.flow.edges.length,
         ...(bundleCount > 1 ? { flows: result.flows.map((f) => ({ id: f.id, name: f.name })) } : {}),
         validation: result.validation,
+        ...(toolName === 'draft_flow'
+          ? {
+              saved: false,
+              rootFlowId: result.flow.id,
+              flow: result.flow,
+              flows: result.flows,
+            }
+          : {}),
         ...(toolName === 'create_flow'
           ? {
               saved: result.saved,


### PR DESCRIPTION
## Summary
- make the compact SimpleFlowSpec schema the guided MCP authoring contract
- stop duplicating the full advanced guide in validate/create tool descriptions
- add get_flow_authoring_guide with on-demand simple and advanced profiles
- add draft_flow, returning the full compiled bundle without saving
- auto-detect legacy nodes+edges specs as advanced for compatibility
- let the shared compile service select simple or advanced lowering

## Tests
- 
pm test -- --runInBand __tests__/mcp/flowAuthoringTools.test.ts __tests__/flow/simpleFlowSpec.test.ts (21 tests passed)

Stacked on #341 and #340. Part of #338.