### PR TITLE
Add Guided and Advanced Flow Builder modes

### DIFF
--- a/__tests__/flow/flowAuthoringProfile.test.ts
+++ b/__tests__/flow/flowAuthoringProfile.test.ts
@@ -1,0 +1,41 @@
+import { flowUsesAdvancedFeatures } from '@/utils/shared/flowAuthoringProfile';
+
+const node = (type: string, properties: Record<string, unknown> = {}) => ({
+  id: type,
+  type,
+  position: { x: 0, y: 0 },
+  data: { label: type, type, properties },
+});
+
+describe('flowUsesAdvancedFeatures', () => {
+  it('keeps the common guided graph in Guided mode', () => {
+    expect(flowUsesAdvancedFeatures({
+      nodes: [
+        node('start'),
+        node('process', {
+          boundModel: 'm1',
+          promptTemplate: 'work',
+          inputMode: 'full-history',
+          outputMode: 'latest-message',
+        }),
+        node('subflow', {
+          subflowId: 'child',
+          inputMode: 'full-history',
+          outputMode: 'final-only',
+        }),
+        node('finish'),
+      ] as never,
+      edges: [],
+    })).toBe(false);
+  });
+
+  it.each([
+    ['resource node', { nodes: [node('resource')], edges: [] }],
+    ['process capture', { nodes: [node('process', { captureVariable: 'result' })], edges: [] }],
+    ['subflow fanout', { nodes: [node('subflow', { allowCallerFanout: true })], edges: [] }],
+    ['conditional edge', { nodes: [], edges: [{ data: { condition: { kind: 'always' } } }] }],
+    ['permissions', { nodes: [], edges: [], permissionRules: [] }],
+  ])('detects %s as advanced', (_label, flow) => {
+    expect(flowUsesAdvancedFeatures(flow as never)).toBe(true);
+  });
+});

--- a/__tests__/frontend/components/FlowBuilderPermissionRules.test.tsx
+++ b/__tests__/frontend/components/FlowBuilderPermissionRules.test.tsx
@@ -46,10 +46,15 @@ const initialFlow: any = {
 };
 
 describe('FlowBuilder permission rules', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('edits, reorders, and saves rules in their displayed order without editor IDs', async () => {
     const onSave = jest.fn();
     render(<FlowBuilder initialFlow={initialFlow} onSave={onSave} onDelete={() => {}} allFlows={[initialFlow]} />);
 
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Guided' }));
     fireEvent.click(screen.getByRole('button', { name: /Permission Rules/i }));
     expect(screen.getByText('Flow permission rules')).toBeInTheDocument();
 
@@ -71,6 +76,7 @@ describe('FlowBuilder permission rules', () => {
     const onSave = jest.fn();
     render(<FlowBuilder initialFlow={initialFlow} onSave={onSave} onDelete={() => {}} allFlows={[initialFlow]} />);
 
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Guided' }));
     fireEvent.click(screen.getByRole('button', { name: /Permission Rules/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Add rule' }));
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));

--- a/docs/features/flowspec-ui-coverage.md
+++ b/docs/features/flowspec-ui-coverage.md
@@ -1,122 +1,80 @@
-# FlowSpec ↔ FlowBuilder UI Coverage
+# Flow authoring profiles
 
-> **Issue #186** — Review & document the gaps between what the **FlowBuilder UI** can
-> author and what is expressible through the **Flow DSL (FlowSpec)** / AI flow generation.
+FLUJO has one flow runtime and two authoring profiles. Both profiles compile to
+the same ReactFlow-compatible definition and execute through the same engine.
 
-This document is the authoritative audit of which FlowSpec capabilities the visual
-**FlowBuilder** can currently author, versus those that today are only reachable through
-the **AI generator** or the **`POST /api/flow/compile`** endpoint.
+## Guided profile
 
-Keep it in sync with the canonical DSL text in
-[`src/utils/shared/flowSpecDoc.ts`](../../src/utils/shared/flowSpecDoc.ts) and the
-compiler in [`src/utils/shared/flowSpecCompiler.ts`](../../src/utils/shared/flowSpecCompiler.ts).
+Guided is the default for the Flow Builder, MCP authoring tools, and automatic
+generation. It is designed for humans who want to describe work and for compact
+models that should not have to choose runtime plumbing.
 
-## TL;DR
+The guided builder exposes:
 
-FLUJO's FlowSpec DSL and the deterministic `FlowSpec → Flow` compiler are effectively
-feature-complete, and the AI generator can emit the full DSL. The FlowBuilder UI, however,
-exposes only a **subset** of these capabilities. The most impactful missing editors are:
+- Process steps: label, task, model, and server tools.
+- Finish steps.
+- Run Another Flow steps: helper flow, label, and task.
+- A compact `SimpleFlowSpec` with ordered steps and optional routes.
 
-- **Edge conditions** (deterministic, model-free routing).
-- **Process-node input/output modes** and **prompt-exclusion flags** (state exists, no rendered controls).
-- **Named-variable / resource / KV capture** (`captureVariable` / `captureResource` / `captureKv`).
-- **Per-node `maxTurns` and `allowedTools`.**
-- **Dynamic subflow fan-out** (`parallelFlowsVariable`, `mapOverList`) — today read-only alerts.
+Start and Finish nodes, ordinary history handoff, layout, node ids, handles,
+edges, and common input/output defaults are inferred.
 
-Until these editors ship, the way to author what the UI can't yet is the AI generator or a
-FlowSpec posted to **`POST /api/flow/compile`** (also exposed through the built-in `flujo`
-MCP server's `create_flow` / `validate_flow_spec` tools).
+## Advanced profile
 
-## Relevant modules
+Advanced is opt-in and preserves the complete FlowSpec and builder surface:
 
-- **DSL / schema (authoritative):** `src/utils/shared/flowSpecCompiler.ts` — `FlowSpecNode`, `FlowSpecEdge`, `FlowSpec`, `compileFlowSpec()`, `applyGenerationDefaults()`.
-- **DSL docs (generator prompt & `/docs`):** `src/utils/shared/flowSpecDoc.ts`.
-- **Edge conditions (Tier 2b):** `src/utils/shared/edgeConditions.ts` — `EdgeCondition`, `evaluateCondition()`.
-- **Generator:** `src/backend/services/flow/generateFlow.ts`; compile endpoint `src/backend/services/flow/compileFlow.ts` (`POST /api/flow/compile`).
-- **FlowBuilder UI root:** `src/frontend/components/Flow/FlowManager/FlowBuilder/` (Canvas, CustomNodes, CustomEdges, Modals, ContextMenu, NodePalette).
-- **Node property modals:** `Modals/ProcessNodePropertiesModal.tsx`, `SubflowNodePropertiesModal.tsx`, `FinishNodePropertiesModal.tsx`, `StartNodePropertiesModal.tsx`, `MCPNodePropertiesModal.tsx`, `ResourceNodePropertiesModal.tsx`, `SignalNodePropertiesModal.tsx`.
-- **Edge creation / rules:** `Canvas/utils/edgeUtils.ts`, `connectionRules.ts`, `nodeUtils.ts`.
-- **UI node factory:** `src/frontend/services/flow/index.ts` (`createNode`).
+- MCP, Resource, Signal, and Trigger nodes.
+- Prompt composition and input/output modes.
+- Conditional/bidirectional edges.
+- Variables, subflow resource capture, persistent KV state, and explicit
+  Process → Resource artifact production.
+- Subflow fan-out, map-over-list, worker spawning, concurrency, joins, and
+  error strategies.
+- Unattended execution and flow-level permission rules.
 
-## Capability matrix — DSL vs. FlowBuilder UI
+The builder preference is stored under `flujo-ui:flow-builder:mode`. When a flow
+contains advanced behavior while Guided is selected, the builder shows a
+non-destructive notice. Hidden properties remain in the saved node data; Guided
+editors do not seed, clear, or rewrite them.
 
-Legend: ✅ supported · ⚠️ partial (state loaded / read-only) · ❌ not in UI
+## Programmatic authoring
 
-| Capability | DSL / Generation | FlowBuilder UI | Gap |
-|---|---|---|---|
-| 7 node types (start/process/finish/mcp/subflow/resource/signal) | ✅ | ✅ create/delete | — |
-| Process: model binding, prompt template, server tools | ✅ | ✅ | — |
-| Process: `inputMode` (full-history/latest-message/isolated) | ✅ | ⚠️ state loaded, no editor | **Gap** |
-| Process: `outputMode` (full-conversation/latest-message) | ✅ | ⚠️ state loaded, no editor | **Gap** |
-| Process: `excludeModelPrompt` / `excludeStartNodePrompt` / `excludeSystemPrompt` | ✅ | ⚠️ state vars exist, not rendered | **Gap** |
-| Process: `maxTurns` | ✅ | ❌ | **Gap** |
-| Process: `allowedTools` (step-level allowlist) | ✅ | ❌ | **Gap** |
-| Process/Subflow: `captureVariable` (`${var:NAME}`) | ✅ | ❌ (insert-only in prompt) | **Gap** |
-| Process/Subflow: `captureResource` (`${res:NAME}`) | ✅ | ❌ | **Gap** |
-| Process/Subflow: `captureKv` (`${kv:NAME}`) | ✅ | ❌ | **Gap** |
-| Edge conditions (contains/regex/equals/always, target, ignoreCase, negate) | ✅ (infra in `edgeUtils.ts`) | ❌ no editor; edge context menu has no "Edit Properties" | **Gap (high value)** |
-| Bidirectional edge toggle | ✅ | ⚠️ right-click exists but undiscoverable | **Gap (discoverability)** |
-| Resource-edge (data-flow) creation | ✅ | ⚠️ shown read-only; not user-creatable via context menu | **Gap** |
-| Subflow: single/parallel-static/spawnBriefs/allowCallerFanout/allowCallerPrompt/concurrency/errorStrategy/joinSeparator | ✅ | ✅ | — |
-| Subflow: `inputMode` / `outputMode` | ✅ | ✅ | — |
-| Subflow: `parallelFlowsVariable` (dynamic fan-out) | ✅ | ⚠️ read-only alert | **Gap** |
-| Subflow: `mapOverList` + `itemSplit` + `sequential` | ✅ | ⚠️ read-only alert | **Gap** |
-| Signal node (`topic`, `payloadTemplate`) | ✅ | ⚠️ modal exists; wiring/coverage to verify | **Verify** |
-| Finish node label normalization | ✅ (generator may emit any label) | ✅ hardcoded "Finish Node" | **Fixed (#188)** |
+| Operation | Default | Advanced access |
+|---|---|---|
+| `create_flow` | SimpleFlowSpec | `profile: "advanced"` or legacy `nodes` + `edges` auto-detection |
+| `validate_flow_spec` | SimpleFlowSpec | same compatibility behavior |
+| `draft_flow` | SimpleFlowSpec, never saves | same compatibility behavior |
+| `get_flow_authoring_guide` | compact schema and rules | `profile: "advanced"` returns the complete FlowSpec guide |
+| `POST /api/flow/compile` | existing advanced contract | unchanged for backward compatibility |
 
-## Finish-node label normalization (#188 — implemented)
+The canonical guided schema and lowerer live in
+`src/utils/shared/simpleFlowSpec.ts`. The complete DSL remains in
+`src/utils/shared/flowSpecCompiler.ts` and `src/utils/shared/flowSpecDoc.ts`.
 
-Finish nodes are identified by **type** (`'finish'`), not label. The UI always renders the
-canonical `"Finish Node"` label (`createNode` in `src/frontend/services/flow/index.ts`,
-read-only modal), but the AI generator may emit **any** custom `label` for a finish node via
-FlowSpec, producing inconsistent naming.
+## Data handoff
 
-**Fix:** `applyGenerationDefaults()` in `src/utils/shared/flowSpecCompiler.ts` now forces
-`node.data.label = 'Finish Node'` for every `node.type === 'finish'`, alongside the existing
-process-node input/output defaults. Because `applyGenerationDefaults()` is called for the root
-flow and every nested subflow bundle in `generateFlow.ts`, finish nodes are normalized at all
-nesting levels.
+Guided flows use conversation history for ordinary step-to-step data. They do
+not expose variable, resource, or KV capture.
 
-## How to author what the UI can't yet
+In Advanced mode:
 
-Anything marked ⚠️ or ❌ above can still be authored **outside the canvas**:
+- `${var:NAME}` reads a run variable.
+- `${res:NAME}` reads a run resource.
+- `${kv:NAME}` reads persistent cross-run state.
+- Subflows may passively capture their concrete folded output as a resource.
+- Processes produce tracked artifacts through an explicit Resource node and the
+  `write_resource` tool; passive Process `captureResource` is unsupported.
 
-1. **AI generator** — describe the flow; the generator emits the full DSL (edge conditions,
-   capture fields, dynamic fan-out, etc.).
-2. **`POST /api/flow/compile`** — send a hand-written FlowSpec (see `flowSpecDoc.ts` for the
-   full grammar) and the deterministic compiler produces a canvas-compatible flow.
-3. **Built-in `flujo` MCP server** — `validate_flow_spec` / `create_flow` accept the same
-   FlowSpec contract.
+`read_resource` dereferences run-resource or native MCP URIs. It is unrelated to
+KV resolution, and ordinary `${res:...}` / `${kv:...}` prompt references are
+resolved by the backend before the model call.
 
-Flows authored this way round-trip through the canvas: the compiler only writes optional fields
-(e.g. `edge.data.condition`) when present, so plain edges/nodes stay byte-compatible with
-UI-authored ones.
+## Compatibility rules
 
-## Prioritized backlog to close the UI gaps
-
-Each slice is independently reviewable and a candidate sub-issue. The issue is titled
-"review and document", so this document (Phase 0) plus #188 is the committed deliverable; the
-following are proposed follow-ups.
-
-1. **Phase 1 — quick wins (half-built):** render process `inputMode` / `outputMode`,
-   `excludeModelPrompt` / `excludeStartNodePrompt` / `excludeSystemPrompt` toggles, and a
-   numeric `maxTurns` field in `ProcessNodePropertiesModal.tsx`.
-2. **Phase 2 — edge conditions (highest-value net-new UI):** an "Edit Properties" edge context
-   menu entry + a new `EdgePropertiesModal` editing `EdgeCondition`, persisted to
-   `edge.data.condition`; a visual badge on conditional edges; make the bidirectional toggle
-   discoverable.
-3. **Phase 3 — data-flow capture editors:** `captureVariable` / `captureResource` / `captureKv`
-   fields (with `${var:}` / `${res:}` / `${kv:}` insert helpers and a KV scope selector) in the
-   process & subflow modals.
-4. **Phase 4 — dynamic subflow fan-out editors:** turn the read-only `parallelFlowsVariable` and
-   `mapOverList` (+ `itemSplit`, `sequential`) alerts in `SubflowNodePropertiesModal.tsx` into
-   real editors.
-5. **Phase 5 — signal / resource node coverage verification:** confirm `SignalNodePropertiesModal`
-   and `ResourceNodePropertiesModal` are fully wired into the canvas/palette; document or fix gaps.
-
-## Constraints observed by the follow-up work
-
-- **UI/compiler parity:** edges/nodes authored in the UI must stay byte-compatible with compiler
-  output (`edgeUtils` spreads `condition` only when present — preserve this).
-- **Backward compatibility:** new optional fields default to current behavior; never break saved flows.
-- **Keep this doc in sync** with `flowSpecDoc.ts` whenever the DSL grows or a gap closes.
+- Switching profiles never removes properties or nodes.
+- Existing advanced FlowSpecs continue to compile.
+- Existing saved flows open in Guided mode with an advanced-feature notice.
+- The vendored Flow Generator is seeded only when missing and is never
+  overwritten on startup. Restoring its bundled definition is explicit.
+- Generated drafts are not saved until the user opens them in the builder and
+  chooses Save.

--- a/src/frontend/components/Flow/FlowManager/FlowBuilder/Modals/ProcessNodePropertiesModal.tsx
+++ b/src/frontend/components/Flow/FlowManager/FlowBuilder/Modals/ProcessNodePropertiesModal.tsx
@@ -52,7 +52,17 @@ const SECTIONS: { key: SectionKey; label: string }[] = [
   { key: 'advanced', label: 'Advanced' },
 ];
 
-export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEdges = [], flowNodes = [], flowId, onConnectMcpServer }: ProcessNodePropertiesModalProps) => {
+export const ProcessNodePropertiesModal = ({
+  open,
+  node,
+  onClose,
+  onSave,
+  flowEdges = [],
+  flowNodes = [],
+  flowId,
+  onConnectMcpServer,
+  authoringMode = 'advanced',
+}: ProcessNodePropertiesModalProps) => {
   log.debug('ProcessNodePropertiesModal rendered with:', { node: node, flowId: flowId });
   const { nodeData, setNodeData, handlePropertyChange } = useNodeData(node);
   const [promptTemplate, setPromptTemplate] = useState('');
@@ -78,6 +88,9 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
   const [activeTab, setActiveTab] = useState<string>('server');
   // Issue #300: the currently active top-level section tab.
   const [activeSection, setActiveSection] = useState<SectionKey>('basic');
+  const visibleSections = authoringMode === 'advanced'
+    ? SECTIONS
+    : SECTIONS.filter((section) => ['basic', 'model', 'task'].includes(section.key));
 
   // Refs for each section, used both for tab-click scroll-into-view and for the
   // IntersectionObserver that keeps the tab bar in sync while the user scrolls.
@@ -97,6 +110,13 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
   // While a programmatic (tab-click) smooth scroll is in flight, ignore the
   // IntersectionObserver so it doesn't flicker the active tab through sections.
   const isProgrammaticScroll = useRef(false);
+
+  useEffect(() => {
+    if (authoringMode === 'guided' && (activeSection === 'io' || activeSection === 'advanced')) {
+      setActiveSection('basic');
+    }
+    if (authoringMode === 'guided' && activeTab !== 'server') setActiveTab('server');
+  }, [activeSection, activeTab, authoringMode]);
 
   const { models, isLoadingModels, loadError, handleModelSelect, handleUnbindModel } = useModelManagement(
     open,
@@ -304,32 +324,36 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
 
   const handleSave = () => {
     if (node && nodeData) {
-      // Make sure to include the prompt template and toggle states in the saved data
       const properties: Record<string, any> = {
         ...nodeData.properties,
         promptTemplate: promptTemplate,
-        excludeModelPrompt: excludeModelPrompt,
-        excludeStartNodePrompt: excludeStartNodePrompt,
-        excludeSystemPrompt: excludeSystemPrompt,
-        inputMode: inputMode,
-        isolatedPrompt: isolatedPrompt,
-        allowCallerPrompt: allowCallerPrompt,
-        outputMode: outputMode,
       };
 
-      // Issue #259: only persist enableTodoTool when ON, so flows that don't use
-      // it stay byte-identical (same delete-when-false convention as captureX).
-      if (enableTodoTool) properties.enableTodoTool = true; else delete properties.enableTodoTool;
+      if (authoringMode === 'advanced') {
+        Object.assign(properties, {
+          excludeModelPrompt,
+          excludeStartNodePrompt,
+          excludeSystemPrompt,
+          inputMode,
+          isolatedPrompt,
+          allowCallerPrompt,
+          outputMode,
+        });
 
-      // Data-flow capture (issue #203): set the trimmed value or REMOVE the key
-      // when empty, so flowToSpec never emits an empty captureX and existing
-      // flows without these fields stay byte-identical.
-      const cv = captureVariable.trim();
-      if (cv) properties.captureVariable = cv; else delete properties.captureVariable;
-      const cr = captureResource.trim();
-      if (cr) properties.captureResource = cr; else delete properties.captureResource;
-      const ckv = buildKvRef(captureKvScope, captureKvKey);
-      if (ckv) properties.captureKv = ckv; else delete properties.captureKv;
+        // Issue #259: only persist enableTodoTool when ON, so flows that don't use
+        // it stay byte-identical (same delete-when-false convention as captureX).
+        if (enableTodoTool) properties.enableTodoTool = true; else delete properties.enableTodoTool;
+
+        // Data-flow capture (issue #203): set the trimmed value or REMOVE the key
+        // when empty, so flowToSpec never emits an empty captureX and existing
+        // flows without these fields stay byte-identical.
+        const cv = captureVariable.trim();
+        if (cv) properties.captureVariable = cv; else delete properties.captureVariable;
+        const cr = captureResource.trim();
+        if (cr) properties.captureResource = cr; else delete properties.captureResource;
+        const ckv = buildKvRef(captureKvScope, captureKvKey);
+        if (ckv) properties.captureKv = ckv; else delete properties.captureKv;
+      }
 
       onSave(node.id, { ...nodeData, properties });
       onClose();
@@ -374,7 +398,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
   // tool bindings share the one mounted promptBuilderRef.
   const toolPanels = (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
+      {authoringMode === 'advanced' && <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
         <Tabs
           value={activeTab}
           onChange={(_, newValue: string) => setActiveTab(newValue)}
@@ -385,7 +409,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
           <Tab label="Resources" value="resources" />
           <Tab label="Agent Tools" value="agent" />
         </Tabs>
-      </Box>
+      </Box>}
 
       <Box sx={{ flexGrow: 1, overflow: 'auto' }}>
         {/* Show Server Tools tab content */}
@@ -410,7 +434,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
         )}
 
         {/* Show Resources tab content */}
-        {activeTab === 'resources' && (
+        {authoringMode === 'advanced' && activeTab === 'resources' && (
           <>
             <WiredResources
               wiredResources={wiredResources}
@@ -425,7 +449,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
         )}
 
         {/* Show Agent Tools tab content */}
-        {activeTab === 'agent' && (
+        {authoringMode === 'advanced' && activeTab === 'agent' && (
           <AgentTools
             handoffTools={handoffTools}
             isLoadingHandoffTools={isLoadingHandoffTools}
@@ -441,16 +465,16 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
     <Dialog
       open={open}
       onClose={onClose}
-      maxWidth="xl"
+      maxWidth={authoringMode === 'advanced' ? 'xl' : 'md'}
       fullWidth
       PaperProps={{
         sx: {
           borderTop: 5,
           borderColor: 'secondary.main',
-          width: '95vw',
-          height: '90vh',
-          maxWidth: '95vw',
-          maxHeight: '90vh',
+          width: authoringMode === 'advanced' ? '95vw' : '80vw',
+          height: authoringMode === 'advanced' ? '90vh' : '85vh',
+          maxWidth: authoringMode === 'advanced' ? '95vw' : '900px',
+          maxHeight: authoringMode === 'advanced' ? '90vh' : '85vh',
         }
       }}
     >
@@ -467,7 +491,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
 
       <Divider />
 
-      <DialogContent sx={{ display: 'flex', flexDirection: 'column', p: 0, overflow: 'hidden', height: 'calc(90vh - 130px)' }}>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', p: 0, overflow: 'hidden', height: authoringMode === 'advanced' ? 'calc(90vh - 130px)' : 'calc(85vh - 130px)' }}>
         {/* Section tab bar — click to scroll a section into view (issue #300). */}
         <Box sx={{ borderBottom: 1, borderColor: 'divider', px: 2, flexShrink: 0 }}>
           <Tabs
@@ -476,7 +500,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
             variant="scrollable"
             scrollButtons="auto"
           >
-            {SECTIONS.map((s) => (
+            {visibleSections.map((s) => (
               <Tab key={s.key} label={s.label} value={s.key} />
             ))}
           </Tabs>
@@ -506,7 +530,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
           </Box>
 
           {/* Input/Output */}
-          <Box ref={ioRef} data-section="io" sx={sectionSx}>
+          {authoringMode === 'advanced' && <Box ref={ioRef} data-section="io" sx={sectionSx}>
             <Typography variant="h6" sx={{ mb: 2 }}>Input / Output</Typography>
             <PromptIOControls
               excludeModelPrompt={excludeModelPrompt}
@@ -538,7 +562,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
               }
               label="Enable todo tool (run-scoped task list)"
             />
-          </Box>
+          </Box>}
 
           {/* Task — tool panels on the LEFT, editor on the RIGHT (as big as
               possible), single mounted editor (issue #300 feedback). */}
@@ -564,7 +588,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
           </Box>
 
           {/* Advanced */}
-          <Box ref={advancedRef} data-section="advanced" sx={sectionSx}>
+          {authoringMode === 'advanced' && <Box ref={advancedRef} data-section="advanced" sx={sectionSx}>
             <Typography variant="h6" sx={{ mb: 2 }}>Advanced</Typography>
             <Box sx={{ mb: 3 }}>
               <NodeProperties nodeData={nodeData} handlePropertyChange={handlePropertyChange} properties={properties} />
@@ -581,7 +605,7 @@ export const ProcessNodePropertiesModal = ({ open, node, onClose, onSave, flowEd
                 onInsertRef={handleInsertCaptureRef}
               />
             </Box>
-          </Box>
+          </Box>}
         </Box>
       </DialogContent>
 

--- a/src/frontend/components/Flow/FlowManager/FlowBuilder/Modals/ProcessNodePropertiesModal/types.ts
+++ b/src/frontend/components/Flow/FlowManager/FlowBuilder/Modals/ProcessNodePropertiesModal/types.ts
@@ -1,6 +1,7 @@
 import { FlowNode } from '@/frontend/types/flow/flow';
 import { Edge } from '@xyflow/react';
 import { Model as SharedModel } from '@/shared/types/model';
+import type { FlowAuthoringMode } from '@/utils/shared/flowAuthoringProfile';
 
 // Re-export the shared Model type
 export type Model = SharedModel;
@@ -20,6 +21,8 @@ export interface ProcessNodePropertiesModalProps {
      * tools.
      */
     onConnectMcpServer?: (serverName: string) => void;
+    /** Guided hides runtime plumbing while preserving every stored property. */
+    authoringMode?: FlowAuthoringMode;
 }
 
 export interface ProcessNodeData {

--- a/src/frontend/components/Flow/FlowManager/FlowBuilder/Modals/SubflowNodePropertiesModal.tsx
+++ b/src/frontend/components/Flow/FlowManager/FlowBuilder/Modals/SubflowNodePropertiesModal.tsx
@@ -36,6 +36,7 @@ import { CardGroup } from '@/utils/shared/cardGrouping';
 import CaptureFields from './shared/CaptureFields';
 import { parseKvRef, buildKvRef, KvRefScope } from '@/utils/shared/resolveKvRefs';
 import { createLogger } from '@/utils/logger';
+import type { FlowAuthoringMode } from '@/utils/shared/flowAuthoringProfile';
 
 const log = createLogger('frontend/components/Flow/FlowManager/FlowBuilder/Modals/SubflowNodePropertiesModal');
 
@@ -46,9 +47,17 @@ interface SubflowNodePropertiesModalProps {
   onSave: (nodeId: string, data: any) => void;
   /** The id of the flow being edited, so it can be excluded from the picker. */
   flowId?: string;
+  authoringMode?: FlowAuthoringMode;
 }
 
-export const SubflowNodePropertiesModal = ({ open, node, onClose, onSave, flowId }: SubflowNodePropertiesModalProps) => {
+export const SubflowNodePropertiesModal = ({
+  open,
+  node,
+  onClose,
+  onSave,
+  flowId,
+  authoringMode = 'advanced',
+}: SubflowNodePropertiesModalProps) => {
   const [nodeData, setNodeData] = useState<{
     label: string;
     type: string;
@@ -141,6 +150,11 @@ export const SubflowNodePropertiesModal = ({ open, node, onClose, onSave, flowId
 
   const handleSave = () => {
     if (node && nodeData) {
+      if (authoringMode === 'guided') {
+        onSave(node.id, nodeData);
+        onClose();
+        return;
+      }
       // Parse the brief editor back into the stored list. An empty editor
       // REMOVES the key (issue #138 spirit: never seed values the user didn't
       // set) rather than persisting an empty array.
@@ -353,6 +367,20 @@ export const SubflowNodePropertiesModal = ({ open, node, onClose, onSave, flowId
           onToggleGroup={flowPicker.toggleGroup}
         />
 
+        {authoringMode === 'guided' && (
+          <TextField
+            fullWidth
+            label="What should this helper do?"
+            value={nodeData.description || ''}
+            onChange={(e) => setNodeData({ ...nodeData, description: e.target.value })}
+            margin="normal"
+            multiline
+            minRows={2}
+            helperText="This instruction is used when another step hands work to the helper flow."
+          />
+        )}
+
+        {authoringMode === 'advanced' && <>
         <Typography variant="subtitle2" sx={{ mt: 3, mb: 1 }}>
           What does the subflow receive?
         </Typography>
@@ -651,6 +679,7 @@ export const SubflowNodePropertiesModal = ({ open, node, onClose, onSave, flowId
             if (patch.captureKvKey !== undefined) setCaptureKvKey(patch.captureKvKey);
           }}
         />
+        </>}
       </DialogContent>
 
       <DialogActions>

--- a/src/frontend/components/Flow/FlowManager/FlowBuilder/NodePalette.tsx
+++ b/src/frontend/components/Flow/FlowManager/FlowBuilder/NodePalette.tsx
@@ -12,6 +12,7 @@ import DescriptionIcon from '@mui/icons-material/Description';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import BoltIcon from '@mui/icons-material/Bolt';
 import { RESOURCE_COLOR, SIGNAL_COLOR, TRIGGER_COLOR, TRIGGER_COLOR_LIGHT } from './CustomNodes';
+import type { FlowAuthoringMode } from '@/utils/shared/flowAuthoringProfile';
 
 // Create a logger instance for this file
 const log = createLogger('components/flow/FlowBuilder/NodePalette.tsx');
@@ -170,7 +171,9 @@ const getNodeIcon = (type: NodeType) => {
   }
 };
 
-export const NodePalette: React.FC = () => {
+export const NodePalette: React.FC<{ authoringMode?: FlowAuthoringMode }> = ({
+  authoringMode = 'guided',
+}) => {
   log.debug(`${COMPONENT_NAME}: Entering component`);
   const theme = useTheme();
   
@@ -230,7 +233,9 @@ export const NodePalette: React.FC = () => {
         Node Types
       </Typography>
       <Box display="flex" flexDirection="column" gap={2}>
-        {nodeTypes.map((node) => (
+        {nodeTypes
+          .filter((node) => authoringMode === 'advanced' || ['process', 'finish', 'subflow'].includes(node.type))
+          .map((node) => (
           <NodeItem
             key={node.type}
             nodeType={node.type}

--- a/src/frontend/components/Flow/FlowManager/FlowBuilder/index.tsx
+++ b/src/frontend/components/Flow/FlowManager/FlowBuilder/index.tsx
@@ -80,6 +80,11 @@ import ImproveFlowDialog, { ImprovedFlowInfo } from '../ImproveFlowDialog';
 import { autoRepairFlow } from '@/utils/shared/flowAutoRepair';
 import { EdgeCondition } from '@/utils/shared/edgeConditions';
 import { Collapse } from '@mui/material';
+import { useUiPreference } from '@/frontend/hooks/useUiPreference';
+import {
+  flowUsesAdvancedFeatures,
+  type FlowAuthoringMode,
+} from '@/utils/shared/flowAuthoringProfile';
 
 /** Pre-filled instruction for AI-supported repair (mirrors the backend repairFlowWithAI). */
 const AI_REPAIR_DESCRIPTION =
@@ -161,6 +166,10 @@ export const FlowBuilder = React.forwardRef<FlowBuilderHandle, FlowBuilderProps>
   // text is driven forward to its single next step instead of silently ending
   // the run. `undefined` = follow the source default (scheduled ON, chat OFF).
   const [flowUnattended, setFlowUnattended] = useState<boolean>(initialFlow?.unattended ?? false);
+  const [authoringMode, setAuthoringMode] = useUiPreference<FlowAuthoringMode>(
+    'flujo-ui:flow-builder:mode',
+    'guided',
+  );
   // Rule IDs are editor-only. PermissionRule has no persisted ID, so keep a
   // stable key separately while still saving the shared rule shape unchanged.
   const permissionRuleIdRef = useRef(0);
@@ -178,6 +187,12 @@ export const FlowBuilder = React.forwardRef<FlowBuilderHandle, FlowBuilderProps>
   );
   const [permissionRulesDialogOpen, setPermissionRulesDialogOpen] = useState(false);
   const [permissionRulesError, setPermissionRulesError] = useState<string | null>(null);
+  const hasHiddenAdvancedFeatures = flowUsesAdvancedFeatures({
+    nodes,
+    edges,
+    unattended: initialFlow?.unattended,
+    permissionRules: initialFlow?.permissionRules,
+  });
 
   // Dialog states
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
@@ -1040,7 +1055,7 @@ export const FlowBuilder = React.forwardRef<FlowBuilderHandle, FlowBuilderProps>
 
   return (
     <FlowBuilderContainer>
-      <NodePalette />
+      <NodePalette authoringMode={authoringMode} />
       <ReactFlowProvider>
         <MainContent>
           <ToolbarContainer elevation={1}>
@@ -1066,6 +1081,24 @@ export const FlowBuilder = React.forwardRef<FlowBuilderHandle, FlowBuilderProps>
             />
 
             <Tooltip
+              describeChild
+              title="Guided shows the common flow controls. Advanced reveals runtime, routing, resource, fan-out, and scheduling controls."
+            >
+              <FormControlLabel
+                control={
+                  <Switch
+                    size="small"
+                    checked={authoringMode === 'advanced'}
+                    onChange={(event) => setAuthoringMode(event.target.checked ? 'advanced' : 'guided')}
+                  />
+                }
+                label={authoringMode === 'advanced' ? 'Advanced' : 'Guided'}
+                sx={{ whiteSpace: 'nowrap' }}
+              />
+            </Tooltip>
+
+            {authoringMode === 'advanced' && <>
+            <Tooltip
               arrow
               title="Unattended: if a step's model stops without handing off, the engine drives the conversation forward to the next step instead of silently ending the run. Recommended for scheduled/headless flows; leave off for interactive chat."
             >
@@ -1089,6 +1122,7 @@ export const FlowBuilder = React.forwardRef<FlowBuilderHandle, FlowBuilderProps>
             >
               Permission Rules{permissionRules.length ? ` (${permissionRules.length})` : ''}
             </Button>
+            </>}
 
             <Button
               variant="contained"
@@ -1203,6 +1237,20 @@ export const FlowBuilder = React.forwardRef<FlowBuilderHandle, FlowBuilderProps>
             <Box sx={{ flex: 1 }} />
           </ToolbarContainer>
 
+          <Collapse in={authoringMode === 'guided' && hasHiddenAdvancedFeatures} unmountOnExit>
+            <Alert
+              severity="info"
+              action={
+                <Button color="inherit" size="small" onClick={() => setAuthoringMode('advanced')}>
+                  Switch to Advanced
+                </Button>
+              }
+              sx={{ mb: 1 }}
+            >
+              This flow contains advanced settings. Guided mode preserves them but hides their editors.
+            </Alert>
+          </Collapse>
+
           {/* One-per-flow Trigger drop notice (issue #241). */}
           <Collapse in={!!triggerDropNotice} unmountOnExit>
             {triggerDropNotice && (
@@ -1261,6 +1309,7 @@ export const FlowBuilder = React.forwardRef<FlowBuilderHandle, FlowBuilderProps>
             handleConnectMcpServer(nodeToEdit.id, serverName);
           }
         }}
+        authoringMode={authoringMode}
       />
       
       <MCPNodePropertiesModal 
@@ -1290,6 +1339,7 @@ export const FlowBuilder = React.forwardRef<FlowBuilderHandle, FlowBuilderProps>
         onClose={() => setSubflowModalOpen(false)}
         onSave={handleNodeUpdate}
         flowId={initialFlow?.id}
+        authoringMode={authoringMode}
       />
 
       <ResourceNodePropertiesModal

--- a/src/utils/shared/flowAuthoringProfile.ts
+++ b/src/utils/shared/flowAuthoringProfile.ts
@@ -1,0 +1,66 @@
+import type { Flow } from '@/shared/types/flow';
+
+export type FlowAuthoringMode = 'guided' | 'advanced';
+
+const ADVANCED_PROCESS_PROPERTIES = new Set([
+  'maxTurns',
+  'excludeModelPrompt',
+  'excludeStartNodePrompt',
+  'excludeSystemPrompt',
+  'allowedTools',
+  'isolatedPrompt',
+  'allowCallerPrompt',
+  'enableTodoTool',
+  'captureVariable',
+  'captureResource',
+  'captureKv',
+  'resourceNodes',
+]);
+
+const ADVANCED_SUBFLOW_PROPERTIES = new Set([
+  'parallelSubflowIds',
+  'parallelSubflowIdsVar',
+  'mapOverList',
+  'itemSplit',
+  'sequential',
+  'allowCallerFanout',
+  'spawnBriefs',
+  'concurrencyLimit',
+  'joinSeparator',
+  'errorStrategy',
+  'allowCallerPrompt',
+  'saveConversation',
+  'captureVariable',
+  'captureResource',
+  'captureKv',
+]);
+
+/** True when Guided mode would hide authored behavior on this flow. */
+export function flowUsesAdvancedFeatures(flow: Pick<Flow, 'nodes' | 'edges' | 'permissionRules' | 'unattended'>): boolean {
+  if (flow.unattended !== undefined || flow.permissionRules !== undefined) return true;
+  for (const node of flow.nodes ?? []) {
+    if (!['start', 'process', 'finish', 'subflow', 'mcp'].includes(node.type ?? '')) return true;
+    const properties = node.data?.properties ?? {};
+    const keys = Object.keys(properties);
+    if (node.type === 'process' && keys.some((key) => ADVANCED_PROCESS_PROPERTIES.has(key))) return true;
+    if (node.type === 'subflow' && keys.some((key) => ADVANCED_SUBFLOW_PROPERTIES.has(key))) return true;
+    if (
+      node.type === 'process' &&
+      (
+        (properties.inputMode !== undefined && properties.inputMode !== 'full-history') ||
+        (properties.outputMode !== undefined && properties.outputMode !== 'latest-message')
+      )
+    ) return true;
+    if (
+      node.type === 'subflow' &&
+      (
+        (properties.inputMode !== undefined && properties.inputMode !== 'full-history') ||
+        (properties.outputMode !== undefined && properties.outputMode !== 'final-only')
+      )
+    ) return true;
+  }
+  return (flow.edges ?? []).some((edge) => {
+    const data = edge.data as Record<string, unknown> | undefined;
+    return !!data?.condition || data?.bidirectional === true || data?.edgeType === 'resource';
+  });
+}


### PR DESCRIPTION
## Summary
- make Guided the persisted default authoring mode and add an explicit Advanced toggle
- limit the Guided palette to Process, Finish, and Run Another Flow
- reduce Guided Process editing to Basic, Model, task prompt, and server tools
- reduce Guided Subflow editing to helper selection, label, and task
- preserve hidden advanced properties without seeding, clearing, or rewriting them
- detect advanced behavior and show a non-destructive switch-to-Advanced notice
- replace the stale UI-gap document with the actual profile, MCP, handoff, and compatibility contract

## Tests
- backend/shared combined suite: 155 tests passed
- Guided/Advanced frontend suite: 15 tests passed
- focused type-check produced no errors in files changed by this series; repository-wide tsc still has the pre-existing MCP/model errors documented in #340

Stacked on #350, #342, #341, and #340.

Closes #338.