### PR TITLE
Encrypt MCP environment credentials centrally and preserve secret metadata

### DIFF
--- a/__tests__/frontend/components/MCPEnvEditor.test.tsx
+++ b/__tests__/frontend/components/MCPEnvEditor.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import EnvEditor from '@/frontend/components/mcp/MCPEnvManager/EnvEditor';
+import { MASKED_STRING } from '@/shared/types/constants';
+
+jest.mock('@/frontend/contexts/StorageContext', () => ({ useStorage: () => ({ globalEnvVars: {} }) }));
+jest.mock('@/frontend/contexts/I18nContext', () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+
+const initialEnv = {
+  GITHUB_TOKEN: { value: 'encrypted:synthetic-ciphertext', metadata: { isSecret: true } },
+  COUNT: { value: '0', metadata: { isSecret: false } },
+};
+
+it('includes an unchanged secret mask in the replacement env map when another field changes', async () => {
+  const onSave = jest.fn().mockResolvedValue(undefined);
+  render(<EnvEditor serverName="github-test" initialEnv={initialEnv} onSave={onSave} />);
+  fireEvent.change(screen.getByDisplayValue('0'), { target: { value: '1' } });
+  fireEvent.click(screen.getByRole('button', { name: 'mcp.env.save' }));
+  await waitFor(() => expect(onSave).toHaveBeenCalledWith({
+    GITHUB_TOKEN: { value: MASKED_STRING, metadata: { isSecret: true } },
+    COUNT: { value: '1', metadata: { isSecret: false } },
+  }));
+});
+
+it('omits a deleted secret row so the backend can remove it', async () => {
+  const onSave = jest.fn().mockResolvedValue(undefined);
+  render(<EnvEditor serverName="github-test" initialEnv={initialEnv} onSave={onSave} />);
+  fireEvent.click(screen.getAllByTitle('mcp.env.remove')[0]);
+  fireEvent.click(screen.getByRole('button', { name: 'mcp.env.save' }));
+  await waitFor(() => expect(onSave).toHaveBeenCalledWith({ COUNT: initialEnv.COUNT }));
+});

--- a/__tests__/mcp/configSecretsAtRest.test.ts
+++ b/__tests__/mcp/configSecretsAtRest.test.ts
@@ -1,0 +1,125 @@
+/** Real MCP persistence and crypto, confined to jest.setup.ts's temporary data root. */
+import { readFile } from 'fs/promises';
+import path from 'path';
+import type { EnvVarValue, MCPServerConfig } from '@/shared/types/mcp';
+import { MASKED_API_KEY, MASKED_STRING } from '@/shared/types/constants';
+import { StorageKey } from '@/shared/types/storage';
+import { loadItem, saveItem } from '@/utils/storage/backend';
+import { getWorkspaceDataDir } from '@/utils/workspace';
+
+jest.mock('@/backend/services/model/encryption', () => {
+  const actual = jest.requireActual('@/backend/services/model/encryption');
+  return { ...actual, encryptApiKey: jest.fn(actual.encryptApiKey) };
+});
+
+import { MCPService } from '@/backend/services/mcp';
+import { encryptApiKey, decryptApiKey } from '@/backend/services/model/encryption';
+
+jest.setTimeout(60000);
+const secret = (value: string): EnvVarValue => ({ value, metadata: { isSecret: true } });
+const plaintext = 'synthetic-github-credential-for-storage-test';
+const encryptedMock = jest.mocked(encryptApiKey);
+let service: MCPService;
+
+async function stored(): Promise<Record<string, MCPServerConfig>> {
+  return loadItem(StorageKey.MCP_SERVERS, {});
+}
+
+beforeEach(async () => {
+  encryptedMock.mockReset().mockImplementation(
+    jest.requireActual<typeof import('@/backend/services/model/encryption')>('@/backend/services/model/encryption').encryptApiKey,
+  );
+  await saveItem(StorageKey.MCP_SERVERS, {});
+  service = new MCPService();
+});
+
+async function create(env: Record<string, EnvVarValue>) {
+  return service.updateServerConfig('github-test', {
+    name: 'github-test', transport: 'stdio', command: 'node', args: [], disabled: true, env,
+  });
+}
+
+it('encrypts installer-style wrapped env in the actual saved file and decrypts it for runtime use', async () => {
+  await create({ GITHUB_TOKEN: secret(plaintext), MCP_IDLE_TIMEOUT_MS: '0' });
+  const env = (await stored())['github-test'].env;
+  expect(env.MCP_IDLE_TIMEOUT_MS).toBe('0');
+  expect(env.GITHUB_TOKEN).toEqual({ value: expect.stringMatching(/^encrypted:/), metadata: { isSecret: true } });
+  const value = (env.GITHUB_TOKEN as { value: string }).value;
+  expect(value).not.toContain(plaintext);
+  await expect(decryptApiKey(value)).resolves.toBe(plaintext);
+  const disk = await readFile(path.join(getWorkspaceDataDir(), 'db', 'mcp_servers.json'), 'utf8');
+  expect(disk).not.toContain(plaintext);
+  expect(disk).not.toContain('encrypted_failed:');
+});
+
+it('infers legacy secret names while respecting explicitly nonsecret fields and global bindings', async () => {
+  await create({
+    GITHUB_TOKEN: plaintext,
+    TOKEN_LABEL: { value: 'public-label', metadata: { isSecret: false } },
+    BOUND: secret('${global:GITHUB_TOKEN}'),
+    EMPTY: secret(''),
+  });
+  const env = (await stored())['github-test'].env;
+  expect(env.GITHUB_TOKEN).toEqual({ value: expect.stringMatching(/^encrypted:/), metadata: { isSecret: true } });
+  expect(env.TOKEN_LABEL).toEqual({ value: 'public-label', metadata: { isSecret: false } });
+  expect(env.BOUND).toEqual(secret('${global:GITHUB_TOKEN}'));
+  expect(env.EMPTY).toEqual(secret(''));
+  expect(encryptedMock).toHaveBeenCalledTimes(1);
+});
+
+it.each([MASKED_STRING, MASKED_API_KEY])('retains the stored secret for UI mask %s while editing another env value', async (mask) => {
+  await create({ GITHUB_TOKEN: secret(plaintext), COUNT: '0' });
+  const previous = (await stored())['github-test'].env.GITHUB_TOKEN;
+  encryptedMock.mockClear();
+  await service.updateServerConfig('github-test', { env: { GITHUB_TOKEN: secret(mask), COUNT: '1' } });
+  expect((await stored())['github-test'].env).toEqual({ GITHUB_TOKEN: previous, COUNT: '1' });
+  expect(encryptedMock).not.toHaveBeenCalled();
+});
+
+it('inherits a custom env secret flag for raw-string updates and masks, unless explicitly turned off', async () => {
+  await create({ CUSTOM_CRED: secret(plaintext) });
+  await service.updateServerConfig('github-test', { env: { CUSTOM_CRED: 'synthetic-rotated-value' } });
+  const previous = (await stored())['github-test'].env.CUSTOM_CRED;
+  expect(previous).toEqual({ value: expect.stringMatching(/^encrypted:/), metadata: { isSecret: true } });
+  await expect(decryptApiKey((previous as { value: string }).value)).resolves.toBe('synthetic-rotated-value');
+  encryptedMock.mockClear();
+  await service.updateServerConfig('github-test', { env: { CUSTOM_CRED: MASKED_STRING } });
+  expect((await stored())['github-test'].env.CUSTOM_CRED).toEqual(previous);
+  expect(encryptedMock).not.toHaveBeenCalled();
+  await service.updateServerConfig('github-test', { env: { CUSTOM_CRED: { value: 'public', metadata: { isSecret: false } } } });
+  expect((await stored())['github-test'].env.CUSTOM_CRED).toEqual({ value: 'public', metadata: { isSecret: false } });
+});
+
+it('does not double-encrypt existing ciphertext, drops orphan masks, and allows explicit deletion', async () => {
+  await create({ GITHUB_TOKEN: secret(plaintext) });
+  const env = (await stored())['github-test'].env;
+  encryptedMock.mockClear();
+  await service.updateServerConfig('github-test', { env: { ...env, MISSING_TOKEN: secret(MASKED_STRING) } });
+  expect((await stored())['github-test'].env).toEqual(env);
+  expect(encryptedMock).not.toHaveBeenCalled();
+  await service.updateServerConfig('github-test', { env: {} });
+  expect((await stored())['github-test'].env).toEqual({});
+});
+
+it.each(['failed-marker', 'plaintext', 'empty', 'throw'])('fails closed without changing persisted config when encryption returns %s', async (failure) => {
+  await create({ COUNT: '0' });
+  const before = await stored();
+  if (failure === 'throw') encryptedMock.mockRejectedValue(new Error(plaintext));
+  else encryptedMock.mockResolvedValue(failure === 'failed-marker' ? `encrypted_failed:${plaintext}` : failure === 'empty' ? '' : plaintext);
+  const result = await service.updateServerConfig('github-test', { env: { GITHUB_TOKEN: secret(plaintext), COUNT: '1' } });
+  expect(result).toEqual({ success: false, error: expect.stringContaining('configuration was not saved') });
+  expect(JSON.stringify(result)).not.toContain(plaintext);
+  expect(await stored()).toEqual(before);
+});
+
+it.each(['env', 'headers', 'oauthClientSecret'])('rejects an incoming failed-encryption marker in %s', async (field) => {
+  const value = `encrypted_failed:${plaintext}`;
+  const updates = field === 'env' ? { env: { GITHUB_TOKEN: secret(value) } }
+    : field === 'headers' ? { headers: { Authorization: secret(value) } }
+      : { oauthClientSecret: value };
+  const result = await service.updateServerConfig('remote-test', {
+    name: 'remote-test', transport: 'streamable', serverUrl: 'https://example.invalid/mcp', disabled: true, env: {}, ...updates,
+  });
+  expect(result).toEqual({ success: false, error: expect.stringContaining('configuration was not saved') });
+  expect(await stored()).toEqual({});
+});

--- a/__tests__/mcp/directInstall.test.ts
+++ b/__tests__/mcp/directInstall.test.ts
@@ -171,6 +171,57 @@ describe('specific MCP source resolution', () => {
 });
 
 describe('specific MCP source installation', () => {
+  it('passes explicit env secrecy through the existing GitHub installer without including values in the plan', async () => {
+    const secret = 'synthetic-github-token';
+    const input = {
+      source: 'https://github.com/acme/mcp-server', serverName: 'github-test',
+      env: { TOKEN: { value: secret, metadata: { isSecret: true } }, OTHER: 'synthetic-other-key', MODE: 'validation-mode' },
+      secretEnvNames: ['OTHER'],
+    };
+    const resolved = await resolveDirectMcpInstall(input);
+    const result = await installResolvedDirectMcp(resolved, input);
+    expect(result.installed).toBe(true);
+    expect(installGithubServerMock).toHaveBeenCalledWith(expect.objectContaining({
+      env: { TOKEN: secret, OTHER: 'synthetic-other-key', MODE: 'validation-mode' },
+      secretEnvNames: ['TOKEN', 'OTHER'],
+      ref: 'a'.repeat(40),
+    }));
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(JSON.stringify(result)).not.toContain('synthetic-other-key');
+  });
+
+  it('preserves wrapped config values and secret flags when overriding env and headers', async () => {
+    const input = {
+      source: {
+        name: 'hosted-secrets', url: 'https://mcp.example.com',
+        env: { TOKEN: { value: 'old-env-secret', metadata: { isSecret: true } } },
+        headers: { 'X-Custom': { value: 'old-header-secret', metadata: { isSecret: true } } },
+      },
+      env: { TOKEN: 'synthetic-env-secret', EXTRA: { value: 'synthetic-extra-secret', metadata: { isSecret: true } } },
+      headers: { 'X-Custom': 'synthetic-header-secret' },
+    };
+    const resolved = await resolveDirectMcpInstall(input);
+    await installResolvedDirectMcp(resolved, input);
+    expect(updateServerConfigMock).toHaveBeenCalledWith('hosted-secrets', expect.objectContaining({
+      env: {
+        TOKEN: { value: 'synthetic-env-secret', metadata: { isSecret: true } },
+        EXTRA: { value: 'synthetic-extra-secret', metadata: { isSecret: true } },
+      },
+      headers: { 'X-Custom': { value: 'synthetic-header-secret', metadata: { isSecret: true } } },
+    }));
+    expect(JSON.stringify(resolved.plan)).not.toContain('synthetic-');
+  });
+
+  it('rejects malformed value metadata without echoing its contents', async () => {
+    await expect(resolveDirectMcpInstall({
+      source: { command: 'npx', args: ['example'], env: { TOKEN: { value: 'synthetic-secret', metadata: { isSecret: 'yes' } } } },
+    })).rejects.toThrow('boolean secret metadata');
+    await expect(resolveDirectMcpInstall({
+      source: 'npx example --token synthetic-secret',
+      env: { TOKEN: { value: 'synthetic-secret', metadata: { isSecret: true } } },
+    })).rejects.toThrow('Credential values must be passed only through env or headers');
+  });
+
   it('saves, connects, and returns the tools for a direct command', async () => {
     const input = { source: 'npx -y @acme/mcp', serverName: 'acme' };
     const resolved = await resolveDirectMcpInstall(input);

--- a/__tests__/mcp/installConsentGate.test.ts
+++ b/__tests__/mcp/installConsentGate.test.ts
@@ -65,6 +65,29 @@ beforeEach(() => {
 });
 
 describe('install_mcp_server consent gate', () => {
+  it.each(['registry', 'command', 'server-json'])('retains caller secret metadata for %s installation and keeps values out of audit', async (kind) => {
+    loadAutoInstallSettingsMock.mockResolvedValue({ ...DEFAULT_MCP_AUTO_INSTALL_SETTINGS });
+    const secret = 'synthetic-api-secret';
+    const source = kind === 'registry' ? 'ai.example/web-search'
+      : kind === 'command' ? 'npx -y @example/direct-mcp'
+        : npmEntry('ai.example/web-search').server;
+    const result = payload(await authoringCallTool('install_mcp_server', {
+      source,
+      env: { TOKEN: { value: secret, metadata: { isSecret: true } }, OTHER: 'synthetic-second-secret' },
+      secretEnvNames: ['OTHER'],
+    }));
+    expect(result.installed).toBe(true);
+    expect(updateServerConfigMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+      env: {
+        TOKEN: { value: secret, metadata: { isSecret: true } },
+        OTHER: { value: 'synthetic-second-secret', metadata: { isSecret: true } },
+      },
+    }));
+    expect(JSON.stringify(appendInstallAuditMock.mock.calls)).not.toContain(secret);
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(JSON.stringify(appendInstallAuditMock.mock.calls)).not.toContain('synthetic-second-secret');
+  });
+
   it('does NOT spawn when consent is required (untrusted) — returns the plan + consentRequired, audits first', async () => {
     // Untrusted authoring tool: brain-stem trust off, consent required, empty allowlist.
     loadAutoInstallSettingsMock.mockResolvedValue({

--- a/__tests__/mcp/internalServer.test.ts
+++ b/__tests__/mcp/internalServer.test.ts
@@ -5,6 +5,15 @@ jest.mock('@/utils/storage/backend', () => ({
   saveItem: jest.fn(),
 }));
 
+jest.mock('@/utils/logger', () => {
+  const log = jest.fn();
+  return {
+    ...jest.requireActual('@/utils/logger'),
+    __testLog: log,
+    createLogger: () => ({ debug: log, verbose: log, info: log, warn: log, error: log }),
+  };
+});
+
 import path from 'node:path';
 import { mcpService } from '@/backend/services/mcp';
 import { resolveStdioLaunch } from '@/backend/services/mcp/connection';
@@ -16,11 +25,12 @@ import {
 } from '@/backend/services/mcp/shippedServers';
 import { loadItem, saveItem } from '@/utils/storage/backend';
 import { StorageKey } from '@/shared/types/storage';
-import type { MCPServerConfig } from '@/shared/types/mcp';
+import type { MCPServerConfig, MCPStdioConfig } from '@/shared/types/mcp';
 import { ensureWorkspaceDirs } from '@/utils/workspace';
 
 const loadItemMock = loadItem as jest.Mock;
 const saveItemMock = saveItem as jest.Mock;
+const logMock = jest.requireMock('@/utils/logger').__testLog as jest.Mock;
 let storage: Map<StorageKey, unknown>;
 
 beforeAll(async () => {
@@ -121,6 +131,32 @@ describe('persisted shipped server configs', () => {
 });
 
 describe('normal stdio delivery', () => {
+  it.each([undefined, '1'])('never logs configured or resolved env values in worker mode %s', (workerMode) => {
+    const priorMode = process.env.FLUJO_WORKER_MODE;
+    try {
+      if (workerMode === undefined) delete process.env.FLUJO_WORKER_MODE;
+      else process.env.FLUJO_WORKER_MODE = workerMode;
+      const config = {
+        name: 'secret-env-test', transport: 'stdio', command: 'node', args: ['server.js'],
+        rootPath: '.', disabled: false, _installCommand: '', _buildCommand: '',
+        env: {
+          TOKEN: { value: 'synthetic-wrapped-secret', metadata: { isSecret: true } },
+          LEGACY_TOKEN: 'synthetic-legacy-secret',
+        },
+      } as MCPStdioConfig;
+      const launch = resolveStdioLaunch(config);
+      expect(launch.env.TOKEN).toBe('synthetic-wrapped-secret');
+      expect(launch.env.LEGACY_TOKEN).toBe('synthetic-legacy-secret');
+      const logs = JSON.stringify(logMock.mock.calls);
+      expect(logs).toContain('TOKEN');
+      expect(logs).not.toContain('synthetic-wrapped-secret');
+      expect(logs).not.toContain('synthetic-legacy-secret');
+    } finally {
+      if (priorMode === undefined) delete process.env.FLUJO_WORKER_MODE;
+      else process.env.FLUJO_WORKER_MODE = priorMode;
+    }
+  });
+
   it('resolves Patchright\'s installation-wide browser cache on supported platforms', () => {
     expect(resolvePlaywrightBrowsersPath({ PLAYWRIGHT_BROWSERS_PATH: ' /shared/browsers ' }, 'linux'))
       .toBe('/shared/browsers');

--- a/src/backend/services/mcp/connection.ts
+++ b/src/backend/services/mcp/connection.ts
@@ -864,7 +864,7 @@ export function resolveStdioLaunch(
     ? resolvedCwd
     : path.join(getWorkspaceDataDir(), resolvedCwd);
   log.debug(`cwd: ${cwd}`);
-  log.debug(`env: ${JSON.stringify(config.env)}`);
+  log.debug(`Environment variable names: ${JSON.stringify(Object.keys(config.env ?? {}))}`);
 
   // Transform the env object to extract only the value part from each key.
   const configuredEnv = transformEnv(config.env);
@@ -915,10 +915,8 @@ export function resolveStdioLaunch(
     );
   }
   log.verbose(
-    "Transformed environment variables",
-    process.env.FLUJO_WORKER_MODE === '1'
-      ? JSON.stringify(Object.keys(transformedEnv))
-      : JSON.stringify(transformedEnv),
+    "Transformed environment variable names",
+    JSON.stringify(Object.keys(transformedEnv)),
   );
 
   // Runtime-only credentials for the bundled FLUJO HTTP client. Do not put

--- a/src/backend/services/mcp/directInstall.ts
+++ b/src/backend/services/mcp/directInstall.ts
@@ -15,6 +15,7 @@ import {
   parseGithubRepositoryReference,
 } from '@/backend/services/mcp/githubInstall';
 import type { EnvVarValue, MCPServerConfig } from '@/shared/types/mcp';
+import { mcpValueRecord, mergeMcpValues, plainMcpValues } from '@/utils/mcp/values';
 import {
   applySpotlightEnvDefaults,
   buildConfigFromOption,
@@ -34,8 +35,9 @@ export interface DirectInstallInput {
   source: unknown;
   serverName?: string;
   transport?: 'stdio' | 'streamable' | 'sse' | 'websocket';
-  env?: Record<string, string>;
-  headers?: Record<string, string>;
+  env?: Record<string, EnvVarValue>;
+  headers?: Record<string, EnvVarValue>;
+  secretEnvNames?: string[];
   ref?: string;
   subdirectory?: string;
   installCommand?: string;
@@ -92,14 +94,6 @@ function objectRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null;
-}
-
-function stringRecord(value: unknown): Record<string, string> {
-  const record = objectRecord(value);
-  if (!record) return {};
-  return Object.fromEntries(
-    Object.entries(record).flatMap(([name, item]) => typeof item === 'string' ? [[name, item]] : []),
-  );
 }
 
 function envValue(value: EnvVarValue | undefined): string {
@@ -324,7 +318,7 @@ function normalizeConfig(
   const common = {
     name,
     disabled: false,
-    env: { ...stringRecord(raw.env), ...(input.env ?? {}) },
+    env: mergeMcpValues(mcpValueRecord(raw.env, input.secretEnvNames), mcpValueRecord(input.env, input.secretEnvNames)),
     _buildCommand: '',
     _installCommand: '',
     rootPath: typeof raw.rootPath === 'string' && raw.rootPath.trim() ? raw.rootPath : transport === 'stdio' ? '.' : `mcp-servers/${name}`,
@@ -346,7 +340,7 @@ function normalizeConfig(
       ...common,
       transport,
       serverUrl: parsed.toString(),
-      headers: { ...stringRecord(raw.headers), ...(input.headers ?? {}) },
+      headers: mergeMcpValues(mcpValueRecord(raw.headers), mcpValueRecord(input.headers)),
       source: { type: 'remote' },
     } as Partial<MCPServerConfig>;
   }
@@ -384,7 +378,7 @@ function planFromConfig(kind: DirectInstallKind, reference: string, config: Part
 
 function assertSecretsOutsidePlan(plan: ResolvedInstallPlan, input: DirectInstallInput): void {
   const serialized = JSON.stringify(plan);
-  const suppliedValues = [...Object.values(input.env ?? {}), ...Object.values(input.headers ?? {})]
+  const suppliedValues = [...Object.values(plainMcpValues(input.env)), ...Object.values(plainMcpValues(input.headers))]
     .filter((value) => value.length >= 4 && !value.startsWith('${global:'));
   if (suppliedValues.some((value) => serialized.includes(value))) {
     throw new Error('Credential values must be passed only through env or headers, never embedded in a command, argument, URL, or install/build command.');
@@ -503,11 +497,11 @@ export async function resolveDirectMcpInstall(input: DirectInstallInput): Promis
     let config = buildConfigFromOption(server, option);
     if (config.transport === 'stdio') assertSupportedCommand(String(config.command ?? ''));
     const serverName = normalizedName(input.serverName, server.name);
-    config = applySpotlightEnvDefaults({ ...config, name: serverName }, input.env);
+    config = applySpotlightEnvDefaults({ ...config, name: serverName }, mcpValueRecord(input.env, input.secretEnvNames));
     if (option.kind === 'remote' && input.headers) {
-      config = { ...config, headers: { ...('headers' in config ? config.headers ?? {} : {}), ...input.headers } } as Partial<MCPServerConfig>;
+      config = { ...config, headers: mergeMcpValues('headers' in config ? config.headers ?? {} : {}, mcpValueRecord(input.headers)) } as Partial<MCPServerConfig>;
     }
-    const supplied = { ...(input.env ?? {}), ...(input.headers ?? {}) };
+    const supplied = { ...plainMcpValues(input.env), ...plainMcpValues(input.headers) };
     const missingInputs = missingRequiredInputs(option, supplied);
     const plan = { ...resolvedPlanFrom(server.name, server, option, 'unverified-direct-server-json'), serverName };
     assertSecretsOutsidePlan(plan, input);
@@ -551,10 +545,12 @@ export async function installResolvedDirectMcp(
   if (existing) return { ...existing, plan: resolved.plan };
 
   if (resolved.kind === 'github' && resolved.github) {
+    const env = mcpValueRecord(input.env, input.secretEnvNames);
     const result = await installGithubServer({
       name: resolved.plan.serverName,
       repositoryUrl: resolved.github.repositoryUrl,
-      env: input.env ?? {},
+      env: plainMcpValues(env),
+      secretEnvNames: Object.entries(env).flatMap(([name, value]) => typeof value === 'object' && value.metadata.isSecret ? [name] : []),
       ...(resolved.github.ref ? { ref: resolved.github.ref } : {}),
       ...(resolved.github.subdirectory ? { subdirectory: resolved.github.subdirectory } : {}),
       ...(resolved.github.installCommand !== undefined ? { installCommand: resolved.github.installCommand } : {}),

--- a/src/backend/services/mcp/flowAuthoringTools.ts
+++ b/src/backend/services/mcp/flowAuthoringTools.ts
@@ -56,6 +56,7 @@ import {
 import { loadAutoInstallSettings, appendInstallAudit } from '@/backend/services/mcp/autoInstall';
 import { decideInstallConsent, planToAuditEntry } from '@/utils/mcp/autoInstallConsent';
 import { isVerifiedStatus } from '@/utils/mcp/registry';
+import { mcpValueRecord } from '@/utils/mcp/values';
 import { modelService } from '@/backend/services/model';
 import {
   assertAllowedArguments,
@@ -66,6 +67,23 @@ import {
 } from './listQuery';
 
 const log = createLogger('backend/services/mcp/flowAuthoringTools');
+
+const installValueSchema = {
+  oneOf: [
+    { type: 'string' },
+    {
+      type: 'object', additionalProperties: false,
+      properties: {
+        value: { type: 'string' },
+        metadata: {
+          type: 'object', additionalProperties: false,
+          properties: { isSecret: { type: 'boolean' } }, required: ['isSecret'],
+        },
+      },
+      required: ['value', 'metadata'],
+    },
+  ],
+};
 
 export const AUTHORING_TOOL_NAMES = [
   'list_flow_building_blocks',
@@ -327,9 +345,10 @@ export function authoringToolDefinitions(): Tool[] {
           env: {
             type: 'object',
             description: 'Optional env var values for the server (e.g. required API keys). Omit them to get needsEnv listing exactly which keys are required.',
-            additionalProperties: { type: 'string' },
+            additionalProperties: installValueSchema,
           },
-          headers: { type: 'object', description: 'Optional headers for a hosted endpoint.', additionalProperties: { type: 'string' } },
+          secretEnvNames: { type: 'array', minItems: 1, items: { type: 'string' }, description: 'Env names whose values must be stored as secrets; alternatively use {value, metadata:{isSecret:true}}.' },
+          headers: { type: 'object', description: 'Optional headers for a hosted endpoint.', additionalProperties: installValueSchema },
           ref: { type: 'string', description: 'Optional Git ref for a GitHub source.' },
           subdirectory: { type: 'string', description: 'Optional GitHub repository subdirectory containing package.json.' },
           installCommand: { type: 'string', description: 'Optional reviewed GitHub dependency-install command.' },
@@ -527,10 +546,8 @@ export async function authoringCallTool(
 
     if (toolName === 'install_mcp_server') {
       const source = args?.source ?? args?.name;
-      const env =
-        args?.env && typeof args.env === 'object' && !Array.isArray(args.env)
-          ? (args.env as Record<string, string>)
-          : undefined;
+      const secretEnvNames = optionalStringArray(args, 'secretEnvNames');
+      const env = args.env === undefined ? undefined : mcpValueRecord(args.env, secretEnvNames);
 
       if (source === undefined || source === null || source === '') {
         return textResult({ error: 'Pass source (or the legacy exact Registry name field).' }, true);
@@ -544,8 +561,9 @@ export async function authoringCallTool(
             ? { transport: args.transport }
             : {}),
           ...(env ? { env } : {}),
-          ...(args.headers && typeof args.headers === 'object' && !Array.isArray(args.headers)
-            ? { headers: args.headers as Record<string, string> }
+          ...(secretEnvNames ? { secretEnvNames } : {}),
+          ...(args.headers !== undefined
+            ? { headers: mcpValueRecord(args.headers) }
             : {}),
           ...(typeof args.ref === 'string' ? { ref: args.ref } : {}),
           ...(typeof args.subdirectory === 'string' ? { subdirectory: args.subdirectory } : {}),

--- a/src/backend/services/mcp/index.ts
+++ b/src/backend/services/mcp/index.ts
@@ -126,6 +126,7 @@ import {
   MCPStreamableConfig,
   MCPSSEConfig,
   MCPHeaderValue,
+  EnvVarValue,
   MCPServiceResponse,
   MCPToolResponse as ToolResponse,
   MCPStdioOAuthStatus,
@@ -198,7 +199,8 @@ import {
   isTransientStreamError,
 } from "@/utils/mcp/utils";
 import { encryptApiKey } from "@/backend/services/model/encryption";
-import { MASKED_API_KEY } from "@/shared/types/constants";
+import { isSecretEnvVar } from "@/utils/shared/common";
+import { mcpValueRecord } from "@/utils/mcp/values";
 import {
   normalizeHeaderValue,
   isMaskedHeaderValue,
@@ -2686,7 +2688,7 @@ export class MCPService {
    * API-key handling so the two behave identically:
    *   - MASKED_API_KEY        -> keep the existing stored secret (the UI never saw the real one)
    *   - "${global:VAR}"       -> a global-variable binding; store the reference verbatim
-   *   - "encrypted[_failed]:"  -> already encrypted; store as-is (idempotent, no double-encrypt)
+   *   - "encrypted:"         -> already encrypted; store as-is (idempotent, no double-encrypt)
    *   - "" (empty)            -> cleared/unbound; store empty
    *   - anything else         -> a freshly typed plaintext secret; encrypt it at rest
    */
@@ -2694,15 +2696,56 @@ export class MCPService {
     incoming: string,
     existing: string | undefined,
   ): Promise<string> {
-    if (incoming === MASKED_API_KEY) return existing ?? "";
+    if (isMaskedHeaderValue(incoming)) incoming = existing ?? "";
     if (!incoming) return "";
     if (incoming.startsWith("${global:")) return incoming;
-    if (
-      incoming.startsWith("encrypted:") ||
-      incoming.startsWith("encrypted_failed:")
-    )
-      return incoming;
-    return await encryptApiKey(incoming);
+    return this.encryptSecretForSave(incoming);
+  }
+
+  /** Never persist the legacy encryption-failure marker, which contains plaintext. */
+  private async encryptSecretForSave(value: string): Promise<string> {
+    if (value.startsWith("encrypted_failed:")) {
+      throw new Error("MCP credential encryption failed");
+    }
+    if (value.startsWith("encrypted:") && value.length > "encrypted:".length) {
+      return value;
+    }
+    const encrypted = await encryptApiKey(value);
+    if (!encrypted.startsWith("encrypted:") || encrypted.length <= "encrypted:".length) {
+      throw new Error("MCP credential encryption failed");
+    }
+    return encrypted;
+  }
+
+  /** Env maps replace the prior map; explicit masks retain secrets, omitted keys delete them. */
+  private async resolveEnvForSave(
+    incoming: Record<string, EnvVarValue>,
+    existing: Record<string, EnvVarValue> | undefined,
+  ): Promise<Record<string, EnvVarValue>> {
+    const result: Record<string, EnvVarValue> = {};
+    for (const [key, raw] of Object.entries(mcpValueRecord(incoming))) {
+      let value = typeof raw === "string" ? raw : raw.value;
+      const previous = existing?.[key];
+      const wasSecret = typeof previous === "object" && previous.metadata.isSecret;
+      const isSecret = typeof raw === "string"
+        ? wasSecret || isSecretEnvVar(key)
+        : raw.metadata.isSecret;
+      if (!isSecret) {
+        result[key] = raw;
+        continue;
+      }
+      if (isMaskedHeaderValue(value)) {
+        if (previous === undefined) continue;
+        value = typeof previous === "string" ? previous : previous.value;
+        // A placeholder without a stored credential must never become a runtime password.
+        if (isMaskedHeaderValue(value)) continue;
+      }
+      result[key] = {
+        value: !value || isGlobalBinding(value) ? value : await this.encryptSecretForSave(value),
+        metadata: { isSecret: true },
+      };
+    }
+    return result;
   }
 
   /**
@@ -2712,7 +2755,7 @@ export class MCPService {
    * they behave identically:
    *   - MASKED_API_KEY / MASKED_STRING -> keep the existing stored value (UI never saw the real one)
    *   - "${global:VAR}"                -> a global-variable binding; store the reference verbatim
-   *   - "encrypted[_failed]:"           -> already encrypted; store as-is (no double-encrypt)
+   *   - "encrypted:"                  -> already encrypted; store as-is (no double-encrypt)
    *   - "" (empty)                     -> cleared; drop the header
    *   - anything else                  -> a freshly typed plaintext secret; encrypt it at rest
    */
@@ -2723,7 +2766,8 @@ export class MCPService {
     const result: Record<string, MCPHeaderValue> = {};
     for (const [key, raw] of Object.entries(incoming || {})) {
       if (!key) continue;
-      const { value, isSecret } = normalizeHeaderValue(raw, key);
+      let { value } = normalizeHeaderValue(raw, key);
+      const { isSecret } = normalizeHeaderValue(raw, key);
 
       if (!isSecret) {
         // Non-secret header: store verbatim (drop empties). Keep the object shape so the
@@ -2737,20 +2781,17 @@ export class MCPService {
       // Secret header handling, mirroring resolveOAuthSecretForSave.
       if (isMaskedHeaderValue(value)) {
         const prev = existing?.[key];
-        if (prev !== undefined) result[key] = prev; // keep the stored (encrypted/bound) value
-        continue;
+        if (prev === undefined) continue;
+        value = normalizeHeaderValue(prev, key).value;
+        if (isMaskedHeaderValue(value)) continue;
       }
       if (!value) continue; // cleared
-      if (
-        isGlobalBinding(value) ||
-        value.startsWith("encrypted:") ||
-        value.startsWith("encrypted_failed:")
-      ) {
+      if (isGlobalBinding(value)) {
         result[key] = { value, metadata: { isSecret: true } };
         continue;
       }
       result[key] = {
-        value: await encryptApiKey(value),
+        value: await this.encryptSecretForSave(value),
         metadata: { isSecret: true },
       };
     }
@@ -2864,39 +2905,32 @@ export class MCPService {
       return { success: false, error: `Server ${serverName} not found` };
     }
 
-    // Keep env `${global:VAR}` bindings verbatim in storage. They are resolved
-    // (and encrypted values decrypted) immediately before each connection in
-    // resolveConfigHeaders, matching custom-header behaviour. Baking globals at
-    // save time made bindings non-portable and prevented rotations from taking
-    // effect until the server was edited again.
+    // Encrypt all credential updates before saving or changing a live connection.
+    // Bindings remain references and are resolved/decrypted at connect time.
+    updates = { ...updates };
+    try {
+      if (updates.env !== undefined) {
+        updates.env = await this.resolveEnvForSave(updates.env, config.env);
+      }
+      const incomingSecret = (updates as Partial<MCPStreamableConfig>).oauthClientSecret;
+      if (incomingSecret !== undefined) {
+        const existingSecret = (config as MCPStreamableConfig).oauthClientSecret;
+        (updates as Partial<MCPStreamableConfig>).oauthClientSecret =
+          await this.resolveOAuthSecretForSave(incomingSecret, existingSecret);
+      }
 
-    // OAuth client secret handling, mirroring model API-key semantics. The browser only ever
-    // sends MASKED_API_KEY (meaning "keep the stored secret"), a "${global:VAR}" binding, or a
-    // freshly typed plaintext secret — never the real stored value. Encrypt plaintext at rest;
-    // keep bindings and already-encrypted values as-is; an empty value clears it.
-    const incomingSecret = (updates as Partial<MCPStreamableConfig>)
-      .oauthClientSecret;
-    if (incomingSecret !== undefined) {
-      const existingSecret = (config as MCPStreamableConfig).oauthClientSecret;
-      (updates as Partial<MCPStreamableConfig>).oauthClientSecret =
-        await this.resolveOAuthSecretForSave(incomingSecret, existingSecret);
+      const incomingHeaders = (updates as Partial<MCPSSEConfig | MCPStreamableConfig>).headers;
+      if (incomingHeaders !== undefined) {
+        const existingHeaders = (config as MCPSSEConfig | MCPStreamableConfig).headers;
+        (updates as Partial<MCPSSEConfig | MCPStreamableConfig>).headers =
+          await this.resolveHeadersForSave(incomingHeaders, existingHeaders);
+      }
+    } catch {
+      // Do not log the original error: encryption failures may contain credential input.
+      return { success: false, error: "Failed to encrypt MCP credentials; configuration was not saved" };
     }
 
-    // Custom-header secret handling (#84), mirroring the OAuth secret contract above. Unlike
-    // env vars (resolved/baked in at save above), header ${global:} bindings are stored
-    // verbatim and resolved fresh at connect time (resolveConfigHeaders) so rotating the bound
-    // global takes effect without re-saving the server.
-    const incomingHeaders = (
-      updates as Partial<MCPSSEConfig | MCPStreamableConfig>
-    ).headers;
-    if (incomingHeaders !== undefined) {
-      const existingHeaders = (config as MCPSSEConfig | MCPStreamableConfig)
-        .headers;
-      (updates as Partial<MCPSSEConfig | MCPStreamableConfig>).headers =
-        await this.resolveHeadersForSave(incomingHeaders, existingHeaders);
-    }
-
-    // Update the config with the new values (including resolved env variables)
+    // Update the config with the protected values.
     let updatedConfig: MCPServerConfig = { ...config };
     updatedConfig = {
       ...config,

--- a/src/backend/services/mcp/registryInstall.ts
+++ b/src/backend/services/mcp/registryInstall.ts
@@ -42,7 +42,7 @@ import { GITHUB_PROVIDER_ID } from '@/backend/services/mcp/quality/providers/git
 import { NPM_PROVIDER_ID } from '@/backend/services/mcp/quality/providers/npmDownloads';
 import { REGISTRY_STATUS_PROVIDER_ID } from '@/backend/services/mcp/quality/providers/registryStatus';
 import { loadQualitySettings } from '@/backend/services/mcp/quality/settings';
-import type { MCPHeaderValue, MCPServerConfig } from '@/shared/types/mcp';
+import type { EnvVarValue, MCPHeaderValue, MCPServerConfig } from '@/shared/types/mcp';
 
 const log = createLogger('backend/services/mcp/registryInstall');
 
@@ -352,7 +352,7 @@ export async function resolveRegistryEntry(registryName: string): Promise<Regist
  */
 export async function prepareRegistryServerRuntime(
   registryName: string,
-  envOverrides?: Record<string, string>,
+  envOverrides?: Record<string, EnvVarValue>,
   options?: InstallOptions
 ): Promise<InstallResult & { config?: Partial<MCPServerConfig> }> {
   if (!registryName || typeof registryName !== 'string') {
@@ -500,7 +500,7 @@ export async function prepareRegistryServerRuntime(
 /** Prepare once, then apply normal adopt-existing and installation semantics. */
 export async function installRegistryServer(
   registryName: string,
-  envOverrides?: Record<string, string>,
+  envOverrides?: Record<string, EnvVarValue>,
   options?: InstallOptions,
 ): Promise<InstallResult> {
   const prepared = await prepareRegistryServerRuntime(registryName, envOverrides, options);

--- a/src/frontend/components/mcp/MCPEnvManager/EnvEditor.tsx
+++ b/src/frontend/components/mcp/MCPEnvManager/EnvEditor.tsx
@@ -262,7 +262,7 @@ const EnvEditor: React.FC<EnvEditorProps> = ({
       // Create env object with resolved values
       const envObject = variables.reduce(
         (acc, variable) => {
-          const { key, value, isBound, boundTo, isSecret, isEncrypted } = variable;
+          const { key, value, isBound, boundTo, isSecret } = variable;
           
           if (!key) return acc; // Skip empty keys
 
@@ -273,13 +273,12 @@ const EnvEditor: React.FC<EnvEditorProps> = ({
               metadata: { isSecret }
             };
           } else {
-            // For all other values, store with metadata, unless it is secret and the value is masked.
-            if (!(isSecret && value === MASKED_STRING)) {
-              acc[key] = {
-                value,
-                metadata: { isSecret }
-              };
-            }
+            // MCP env is a replacement map. Send the mask so the backend can retain
+            // an unchanged encrypted value; only deleted rows should disappear.
+            acc[key] = {
+              value,
+              metadata: { isSecret }
+            };
           }
           return acc;
         },

--- a/src/frontend/hooks/useServerStatus.ts
+++ b/src/frontend/hooks/useServerStatus.ts
@@ -469,7 +469,7 @@ export function useServerStatus() {
     serverName: string, 
     env: Record<string, { value: string, metadata: { isSecret: boolean } } | string>
   ) => {
-    log.debug(`Saving environment variables for server: ${serverName}`, env);
+    log.debug(`Saving environment variables for server: ${serverName}`, { variableNames: Object.keys(env) });
     try {
       const server = servers.find((s) => s.name === serverName);
       if (!server) {

--- a/src/utils/mcp/registry.ts
+++ b/src/utils/mcp/registry.ts
@@ -19,6 +19,7 @@
  */
 
 import { MCPServerConfig, EnvVarValue, MCPServerIcon, MCPServerSource, MCPLaunchSpec } from '@/shared/types/mcp/mcp';
+import { mergeMcpValues, plainMcpValues } from './values';
 
 // ---------------------------------------------------------------------------
 // Registry API shapes (subset of server.schema.json that we consume)
@@ -923,18 +924,10 @@ export function firstServerFromResponse(body: unknown): RegistryServerResult | n
  */
 export function applySpotlightEnvDefaults(
   config: Partial<MCPServerConfig>,
-  overrides?: Record<string, string>
+  overrides?: Record<string, EnvVarValue>
 ): Partial<MCPServerConfig> {
   if (!overrides || Object.keys(overrides).length === 0) return config;
-  const env: Record<string, EnvVarValue> = { ...(config.env ?? {}) };
-  for (const [name, value] of Object.entries(overrides)) {
-    const existing = env[name];
-    if (existing && typeof existing === 'object' && existing.metadata?.isSecret) {
-      env[name] = { value, metadata: { isSecret: true } };
-    } else {
-      env[name] = value;
-    }
-  }
+  const env = mergeMcpValues(config.env, overrides);
   // Same cast the config builders above use: MCPServerConfig types env as an
   // intersection that a plain Record<string, EnvVarValue> can't satisfy.
   return { ...config, env } as Partial<MCPServerConfig>;
@@ -947,14 +940,15 @@ export function applySpotlightEnvDefaults(
  */
 export function missingRequiredInputs(
   option: InstallOption,
-  envOverrides?: Record<string, string>
+  envOverrides?: Record<string, EnvVarValue>
 ): string[] {
+  const supplied = plainMcpValues(envOverrides);
   if (option.kind === 'remote') {
     return (option.remote.headers ?? [])
-      .filter(h => h.isRequired && !(h.value ?? h.default) && !envOverrides?.[h.name])
+      .filter(h => h.isRequired && !(h.value ?? h.default) && !supplied[h.name])
       .map(h => h.name);
   }
   return (option.pkg.environmentVariables ?? [])
-    .filter(v => v.isRequired && !(v.value ?? v.default) && !envOverrides?.[v.name])
+    .filter(v => v.isRequired && !(v.value ?? v.default) && !supplied[v.name])
     .map(v => v.name);
 }

--- a/src/utils/mcp/values.ts
+++ b/src/utils/mcp/values.ts
@@ -1,0 +1,35 @@
+import type { EnvVarValue } from '@/shared/types/mcp';
+
+/** Accept the persisted MCP value shape without dropping explicit secret metadata. */
+export function mcpValueRecord(value: unknown, secretNames: readonly string[] = []): Record<string, EnvVarValue> {
+  if (value === undefined) return {};
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('MCP environment variables and headers must be objects.');
+  }
+  return Object.fromEntries(Object.entries(value).map(([name, raw]) => {
+    if (typeof raw === 'string') {
+      return [name, secretNames.includes(name) ? { value: raw, metadata: { isSecret: true } } : raw];
+    }
+    if (raw && typeof raw === 'object' && typeof raw.value === 'string'
+      && raw.metadata && typeof raw.metadata.isSecret === 'boolean') {
+      return [name, { value: raw.value, metadata: { isSecret: raw.metadata.isSecret || secretNames.includes(name) } }];
+    }
+    throw new Error('Each MCP environment variable or header must be a string or a value with boolean secret metadata.');
+  }));
+}
+
+export function plainMcpValues(values?: Record<string, EnvVarValue>): Record<string, string> {
+  return Object.fromEntries(Object.entries(values ?? {}).map(([name, raw]) => [name, typeof raw === 'string' ? raw : raw.value]));
+}
+
+/** Replacing a value never silently removes the registry/config's secret flag. */
+export function mergeMcpValues(base: Record<string, EnvVarValue> = {}, overrides: Record<string, EnvVarValue> = {}): Record<string, EnvVarValue> {
+  const merged = { ...base };
+  for (const [name, value] of Object.entries(overrides)) {
+    const existing = merged[name];
+    merged[name] = existing && typeof existing === 'object' && existing.metadata?.isSecret
+      ? { value: typeof value === 'string' ? value : value.value, metadata: { isSecret: true } }
+      : value;
+  }
+  return merged;
+}


### PR DESCRIPTION
API-installed MCP environment credentials could be saved in plaintext because MCPService.updateServerConfig encrypted OAuth credentials and headers but did not protect environment values. This PR encrypts secret environment values at the central save boundary, preserves masked credentials during edits, and keeps environment values out of launch logs.

- Encrypt explicit secret values and recognized legacy secret environment names before saving or changing a live connection. Preserve global-variable references, existing ciphertext, explicit clearing, and replacement-map deletion semantics.
- Reject encryption failures without persisting the legacy plaintext-bearing failure marker, mutating the stored configuration, or exposing credential input in logs/errors. Apply the same fail-closed handling to OAuth and header secrets.
- Preserve secret metadata through authoring, registry, direct/server-JSON, and GitHub installation. Support both strings and the existing wrapped value shape, including optional secretEnvNames.
- Keep masked environment values masked in the editor and carry secret metadata through status/edit flows. Log environment names only for both local and cloud-worker launches.

Validation: 105 focused tests, typecheck, and lint passed before publication, including real encryption against temporary files. Regression coverage includes plaintext-at-rest prevention, masked updates, bindings, ciphertext reuse, encryption failures, installer metadata retention, UI masking, and log/audit redaction. A live local integration test also confirmed that the real GitHub credential was encrypted on disk and absent from plaintext configuration and logs. The default FLUJO flow, using Astra and a pinned GitHub MCP server, created exactly one comment in a dedicated test repository and read it back. Parallel cloud-worker validation is running separately; this PR contains no workspace data or credentials.

CI: lint, typecheck, and every installer/artifact check pass. [The PR verification run](https://github.com/mario-andreschak/FLUJO/actions/runs/33992022879) has 6,601 passing main-suite tests and exactly the same 14 failing cases as [main at 48503d8c](https://github.com/mario-andreschak/FLUJO/actions/runs/33991014090), with no new failures. The isolated stage has 73 passing tests and only the unchanged pre-existing Persona soak failure. Existing baseline failures are not suppressed by this PR.

Follow-up to #503. The main-branch merge only brings in its completed test/CI integration history; the production source remains the two validated secret-handling commits.


