### PR TITLE
Make cloud worker discovery and image publication automatic

### DIFF
--- a/.github/workflows/publish-cloud-worker.yml
+++ b/.github/workflows/publish-cloud-worker.yml
@@ -1,0 +1,132 @@
+name: Publish Cloud Worker Image
+
+# Independent from npm/releases and :latest. Only a tested main revision can
+# advance the worker channel; manual runs are useful after a transient CI failure.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'mcp-servers/**'
+      - 'scripts/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'next.config.mjs'
+      - 'tsconfig.json'
+      - 'postcss.config.*'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/publish-cloud-worker.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: publish-cloud-worker
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main' && github.repository == 'mario-andreschak/FLUJO'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/mario-andreschak/flujo
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Read application version
+        id: version
+        run: |
+          node -e 'const fs=require("fs"); const version=require("./package.json").version; if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?$/.test(version)) throw Error("Invalid image version"); fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${version}\n`);'
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build Linux worker image without publishing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: flujo-cloud-worker-smoke:${{ github.sha }}
+          build-args: |
+            FLUJO_APPLICATION_VERSION=${{ steps.version.outputs.version }}
+            FLUJO_BUILD_REVISION=${{ github.sha }}
+          cache-from: type=gha,scope=cloud-worker
+          cache-to: type=gha,scope=cloud-worker,mode=max
+
+      - name: Validate exact image and run offline production worker smoke
+        id: smoke
+        env:
+          APPLICATION_VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_id="$(docker image inspect --format '{{.Id}}' "flujo-cloud-worker-smoke:${GITHUB_SHA}")"
+          docker image inspect "$image_id" > "$RUNNER_TEMP/cloud-worker-image.json"
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+          import assert from 'node:assert/strict';
+          const [image] = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/cloud-worker-image.json`, 'utf8'));
+          assert.equal(image.Os, 'linux');
+          assert.equal(image.Architecture, 'amd64');
+          assert.equal(image.Config.User, 'node');
+          for (const [key, value] of Object.entries({
+            'io.flujo.application.version': process.env.APPLICATION_VERSION,
+            'io.flujo.snapshot.format': '2', 'io.flujo.workspace.layout': '2', 'io.flujo.worker.protocol': '1',
+            'org.opencontainers.image.revision': process.env.GITHUB_SHA,
+            'org.opencontainers.image.source': 'https://github.com/mario-andreschak/FLUJO',
+          })) assert.equal(image.Config.Labels[key], value, `Incorrect ${key}`);
+          NODE
+          # The test creates an encrypted synthetic snapshot and local mock model
+          # inside the container, rehydrates a bundled MCP process, executes a real
+          # flow, then restarts Next and checks durable results. No provider/GitHub
+          # credentials, host workspace mounts, or network access are supplied.
+          docker run --rm --network none --read-only --no-healthcheck \
+            --tmpfs /tmp:rw,exec,nosuid,nodev,size=536870912 \
+            --cap-drop ALL --security-opt no-new-privileges --pids-limit 256 \
+            "$image_id" node scripts/smoke-cloud-worker.mjs --production
+          echo "image_id=$image_id" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish the tested image without rebuilding
+        env:
+          IMAGE_ID: ${{ steps.smoke.outputs.image_id }}
+          APPLICATION_VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          revision_tag="${IMAGE}:cloud-worker-${GITHUB_SHA}"
+          # Revision tags are write-once. Preserve an earlier tested image if the
+          # same workflow revision is rerun after a partial channel push. Re-test
+          # that exact prior image before completing its channel promotion.
+          if docker manifest inspect "$revision_tag" >/dev/null 2>&1; then
+            docker pull "$revision_tag"
+            IMAGE_ID="$(docker image inspect --format '{{.Id}}' "$revision_tag")"
+            test "$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$IMAGE_ID")" = "$GITHUB_SHA"
+            test "$(docker image inspect --format '{{index .Config.Labels "io.flujo.application.version"}}' "$IMAGE_ID")" = "$APPLICATION_VERSION"
+            docker run --rm --network none --read-only --no-healthcheck \
+              --tmpfs /tmp:rw,exec,nosuid,nodev,size=536870912 \
+              --cap-drop ALL --security-opt no-new-privileges --pids-limit 256 \
+              "$IMAGE_ID" node scripts/smoke-cloud-worker.mjs --production
+          else
+            docker tag "$IMAGE_ID" "$revision_tag"
+            docker push "$revision_tag"
+          fi
+          for tag in "${IMAGE}:cloud-worker-${APPLICATION_VERSION}" "${IMAGE}:cloud-worker"; do
+            docker tag "$IMAGE_ID" "$tag"
+            docker push "$tag"
+          done
+          echo "Published tested cloud worker revision ${GITHUB_SHA}." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -41,6 +41,10 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      - name: Read package.json version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Build local image for process-boundary smoke
         uses: docker/build-push-action@v6
         with:
@@ -48,6 +52,9 @@ jobs:
           load: true
           push: false
           tags: flujo-process-boundary-smoke:${{ github.sha }}
+          build-args: |
+            FLUJO_APPLICATION_VERSION=${{ steps.version.outputs.version }}
+            FLUJO_BUILD_REVISION=${{ github.sha }}
           cache-from: type=gha
 
       - name: Exercise MCP proxy in the local image
@@ -74,10 +81,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read package.json version
-        id: version
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-
       - name: Docker metadata (tags + OCI labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -95,5 +98,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            FLUJO_APPLICATION_VERSION=${{ steps.version.outputs.version }}
+            FLUJO_BUILD_REVISION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,24 @@ RUN NODE_OPTIONS=--max-old-space-size=4096 npm run build
 FROM node:22-bookworm-slim AS runtime
 WORKDIR /app
 
+# CI supplies these from the checked-out source before building. Empty defaults
+# deliberately do not claim compatibility or a published revision for an
+# unlabelled local build. The worker resolver requires the complete labels.
+ARG FLUJO_APPLICATION_VERSION=""
+ARG FLUJO_BUILD_REVISION=""
+LABEL io.flujo.application.version="${FLUJO_APPLICATION_VERSION}" \
+      io.flujo.snapshot.format="2" \
+      io.flujo.workspace.layout="2" \
+      io.flujo.worker.protocol="1" \
+      org.opencontainers.image.version="${FLUJO_APPLICATION_VERSION}" \
+      org.opencontainers.image.revision="${FLUJO_BUILD_REVISION}" \
+      org.opencontainers.image.source="https://github.com/mario-andreschak/FLUJO"
+
 # Mark the install so /api/update reports "pull a new image" instead of a
 # broken in-app git updater. The MCP Apps sandbox is a second browser origin;
 # containers listen beyond loopback while publication remains runner-controlled.
 ENV NODE_ENV=production \
+    FLUJO_BUILD_REVISION=${FLUJO_BUILD_REVISION} \
     FLUJO_CONTAINER=1 \
     FLUJO_APP_ROOT=/app \
     FLUJO_DATA_DIR=/app/data \
@@ -72,6 +86,13 @@ RUN curl -LsSf https://astral.sh/uv/install.sh \
 # packages before npm ci so their exact root dependency pins become local links;
 # `npx --no-install` can then resolve every shipped binary without a registry.
 COPY --from=builder /app/package.json /app/package-lock.json ./
+# A mistyped build argument must not advertise a version this image cannot restore.
+RUN if [ -n "$FLUJO_APPLICATION_VERSION" ]; then \
+      node -e 'if (require("./package.json").version !== process.argv[1]) process.exit(1)' "$FLUJO_APPLICATION_VERSION"; \
+    fi \
+    && if [ -n "$FLUJO_BUILD_REVISION" ]; then \
+      node -e 'if (!/^[a-f0-9]{40}$/.test(process.env.FLUJO_BUILD_REVISION)) process.exit(1)'; \
+    fi
 COPY --from=builder /app/mcp-servers ./mcp-servers
 # Reuse the browser payload downloaded by the workspace install lifecycle in the
 # builder. The following npm ci sees the version marker and does not download it again.

--- a/__tests__/encryption/lockGate.test.ts
+++ b/__tests__/encryption/lockGate.test.ts
@@ -155,6 +155,9 @@ describe('deny-by-default coverage guard', () => {
       // Installation-wide namespace discovery contains no workspace content and
       // must remain reachable so the locked shell can validate its active tab.
       'src/app/api/workspaces/route.ts',
+      // Strict-loopback instance proof contains no workspace data or bearer and
+      // must permit discovery before storage migration/unlock has completed.
+      'src/app/api/cloud/instance/route.ts',
       // Snapshot control has a separate strict-loopback + dedicated bearer
       // boundary. Status/abort/finalize must remain usable during encryption
       // transitions; USER snapshot capture itself refuses an unavailable DEK.

--- a/__tests__/security/localInstance.test.ts
+++ b/__tests__/security/localInstance.test.ts
@@ -1,0 +1,134 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createHmac } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { prepareLocalInstance, readPrivateJson, createLocalInstanceProof, withLocalInstanceHostname } from '../../scripts/local-instance.mjs';
+import { forwardNextShutdown } from '../../scripts/launch-next.mjs';
+
+jest.mock('@next/env', () => ({ __esModule: true, default: { loadEnvConfig: jest.fn() } }));
+
+jest.setTimeout(60000);
+let root: string;
+beforeEach(async () => { root = await fs.mkdtemp(path.join(os.tmpdir(), 'flujo-instance-test-')); });
+afterEach(async () => {
+  expect(path.basename(root)).toMatch(/^flujo-instance-test-/);
+  await fs.rm(root, { recursive: true, force: true });
+});
+const environment = () => ({ FLUJO_EXPOSURE_MODE: 'localhost', FLUJO_LOCAL_INSTANCE_DIR: path.join(root, 'instances'),
+  FLUJO_DATA_DIR: path.join(root, 'data') });
+
+it('generates and privately registers a unique native instance with the actual child identity', async () => {
+  const instance = await prepareLocalInstance({ env: environment(), args: ['start', '-p', '4210', '-H', '127.0.0.1'], appRoot: root });
+  expect(instance.env.FLUJO_SNAPSHOT_CONTROL_TOKEN).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  await instance.register(process.pid);
+  const filename = path.join(root, 'instances', `${instance.env.FLUJO_LOCAL_INSTANCE_ID}.json`);
+  const record = await readPrivateJson(filename);
+  expect(record).toMatchObject({ format: 'flujo-local-instance', version: 1, pid: process.pid,
+    origin: 'http://127.0.0.1:4210', appRoot: root, dataRoot: path.join(root, 'data'),
+    token: instance.env.FLUJO_SNAPSHOT_CONTROL_TOKEN });
+  const nonce = 'a'.repeat(64);
+  const proof = createLocalInstanceProof(nonce, instance.env);
+  expect(proof?.proof).toBe(createHmac('sha256', record.token)
+    .update(`flujo-local-instance:v1\n${nonce}\n${record.instanceId}\n${record.origin}`).digest('base64url'));
+  expect(JSON.stringify(proof)).not.toContain(record.token);
+  instance.cleanup();
+  await expect(fs.stat(filename)).rejects.toMatchObject({ code: 'ENOENT' });
+});
+
+it('preserves an explicit token and creates independent descriptors for separate launches', async () => {
+  const env = { ...environment(), FLUJO_SNAPSHOT_CONTROL_TOKEN: 'synthetic-explicit-source-token-0123456789' };
+  const first = await prepareLocalInstance({ env, appRoot: root });
+  const second = await prepareLocalInstance({ env, appRoot: root });
+  expect(first.env.FLUJO_SNAPSHOT_CONTROL_TOKEN).toBe(env.FLUJO_SNAPSHOT_CONTROL_TOKEN);
+  expect(first.env.FLUJO_LOCAL_INSTANCE_ID).not.toBe(second.env.FLUJO_LOCAL_INSTANCE_ID);
+  await first.register(process.pid);
+  await second.register(process.pid);
+  expect(await fs.readdir(path.join(root, 'instances'))).toHaveLength(2);
+  first.cleanup();
+  second.cleanup();
+});
+
+it.each([
+  { FLUJO_WORKER_MODE: '1' }, { FLUJO_CONTAINER: '1' }, { FLUJO_EXPOSURE_MODE: 'network' }, { FLUJO_EXPOSURE_MODE: 'public' },
+])('skips auto credentials and registration for unsupported mode %j', async (override) => {
+  const instance = await prepareLocalInstance({ env: { ...environment(), ...override }, appRoot: root });
+  await instance.register(process.pid);
+  expect(instance.env.FLUJO_SNAPSHOT_CONTROL_TOKEN).toBeUndefined();
+  expect(instance.env.FLUJO_LOCAL_INSTANCE_ID).toBeUndefined();
+  await expect(fs.stat(path.join(root, 'instances'))).rejects.toMatchObject({ code: 'ENOENT' });
+});
+
+it('does not auto-enable capture for explicit wildcard binds and rejects linked registries', async () => {
+  const skipped = await prepareLocalInstance({ env: environment(), args: ['start', '-H', '0.0.0.0'], appRoot: root });
+  expect(skipped.env.FLUJO_SNAPSHOT_CONTROL_TOKEN).toBeUndefined();
+  const target = path.join(root, 'target');
+  await fs.mkdir(target);
+  await fs.symlink(target, path.join(root, 'instances'), process.platform === 'win32' ? 'junction' : 'dir');
+  await expect(prepareLocalInstance({ env: environment(), appRoot: root })).rejects.toThrow(/unsafe/);
+});
+
+it('rejects registry overrides inside a workspace before creating private credentials there', async () => {
+  const directory = path.join(root, 'data', 'workspaces', 'test', 'db', 'instances');
+  await expect(prepareLocalInstance({ env: { ...environment(), FLUJO_LOCAL_INSTANCE_DIR: directory }, appRoot: root }))
+    .rejects.toThrow(/outside workspace snapshots/);
+  await expect(fs.stat(directory)).rejects.toMatchObject({ code: 'ENOENT' });
+});
+
+it.each([['-H', 'localhost'], ['--hostname', 'localhost'], ['--hostname=localhost']])(
+  'uses one numeric bind and proof origin for explicit localhost arguments %j', async (...hostnameArgs) => {
+    const args = ['start', '-p', '4210', ...hostnameArgs];
+    const normalized = withLocalInstanceHostname(args, environment());
+    expect(normalized.join(' ')).not.toContain('localhost');
+    expect(normalized.join(' ')).toContain('127.0.0.1');
+    expect(args.join(' ')).toContain('localhost');
+    const instance = await prepareLocalInstance({ env: environment(), args: normalized, appRoot: root });
+    expect(instance.env.FLUJO_LOCAL_INSTANCE_ORIGIN).toBe('http://127.0.0.1:4210');
+    expect(createLocalInstanceProof('a'.repeat(64), instance.env)?.origin).toBe('http://127.0.0.1:4210');
+    instance.cleanup();
+  },
+);
+
+it('preserves explicitly requested IPv6 and unsupported exposure hostname arguments', async () => {
+  const args = ['start', '-p', '4210', '--hostname', '::1'];
+  expect(withLocalInstanceHostname(args, environment())).toEqual(args);
+  const instance = await prepareLocalInstance({ env: environment(), args, appRoot: root });
+  expect(instance.env.FLUJO_LOCAL_INSTANCE_ORIGIN).toBe('http://[::1]:4210');
+  instance.cleanup();
+  const network = ['start', '--hostname=localhost'];
+  expect(withLocalInstanceHostname(network, { FLUJO_EXPOSURE_MODE: 'network' })).toEqual(network);
+});
+
+it('native shutdown forwards the signal and removes its private registration', async () => {
+  const instance = await prepareLocalInstance({ env: environment(), appRoot: root });
+  const registered = instance.register(process.pid);
+  await registered;
+  const filename = path.join(root, 'instances', `${instance.env.FLUJO_LOCAL_INSTANCE_ID}.json`);
+  const child = Object.assign(new EventEmitter(), { exitCode: null, signalCode: null, kill: jest.fn() });
+  const parent = Object.assign(new EventEmitter(), { platform: 'win32', pid: 1, exit: jest.fn(), kill: jest.fn() });
+  forwardNextShutdown(child, instance, registered, { parent: parent as unknown as NodeJS.Process });
+  parent.emit('SIGTERM');
+  expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  await expect(fs.stat(filename)).rejects.toMatchObject({ code: 'ENOENT' });
+  child.emit('exit', null, 'SIGTERM');
+  await new Promise(setImmediate);
+  expect(parent.exit).toHaveBeenCalledWith(1);
+});
+
+it('shutdown waits for registration cleanup before preserving POSIX signal semantics', async () => {
+  let finishRegistration!: () => void;
+  const registered = new Promise<void>((resolve) => { finishRegistration = resolve; });
+  const instance = { cleanup: jest.fn() };
+  const child = Object.assign(new EventEmitter(), { exitCode: null, signalCode: null, kill: jest.fn() });
+  const parent = Object.assign(new EventEmitter(), { platform: 'linux', pid: 1, exit: jest.fn(), kill: jest.fn() });
+  forwardNextShutdown(child, instance, registered, { parent: parent as unknown as NodeJS.Process });
+  parent.emit('SIGINT');
+  child.emit('exit', null, 'SIGINT');
+  expect(instance.cleanup).toHaveBeenCalledTimes(1);
+  expect(parent.kill).not.toHaveBeenCalled();
+  finishRegistration();
+  await new Promise(setImmediate);
+  expect(instance.cleanup).toHaveBeenCalledTimes(2);
+  expect(parent.listenerCount('SIGINT')).toBe(0);
+  expect(parent.kill).toHaveBeenCalledWith(1, 'SIGINT');
+});

--- a/__tests__/security/localInstanceRoute.test.ts
+++ b/__tests__/security/localInstanceRoute.test.ts
@@ -1,0 +1,46 @@
+import { createHmac } from 'node:crypto';
+import { GET } from '@/app/api/cloud/instance/route';
+
+const token = 'synthetic-local-instance-proof-token-0123456789';
+const instanceId = 'f3d2b631-9ab3-4c34-a16d-d352f0274034';
+const origin = 'http://127.0.0.1:4200';
+const nonce = 'a'.repeat(64);
+const request = (headers: Record<string, string> = {}, challenge = nonce) => new Request(`${origin}/api/cloud/instance?nonce=${challenge}`, {
+  headers: { host: '127.0.0.1:4200', ...headers },
+});
+beforeEach(() => {
+  process.env.FLUJO_EXPOSURE_MODE = 'localhost';
+  process.env.FLUJO_LOCAL_INSTANCE_ID = instanceId;
+  process.env.FLUJO_LOCAL_INSTANCE_ORIGIN = origin;
+  process.env.FLUJO_SNAPSHOT_CONTROL_TOKEN = token;
+  delete process.env.FLUJO_WORKER_MODE;
+  delete process.env.FLUJO_CONTAINER;
+});
+afterEach(() => {
+  for (const name of ['FLUJO_EXPOSURE_MODE', 'FLUJO_LOCAL_INSTANCE_ID', 'FLUJO_LOCAL_INSTANCE_ORIGIN', 'FLUJO_SNAPSHOT_CONTROL_TOKEN', 'FLUJO_WORKER_MODE', 'FLUJO_CONTAINER']) delete process.env[name];
+});
+
+it('returns only a bound HMAC proof without an unlock, migration, or workspace dependency', async () => {
+  const response = GET(request());
+  expect(response.status).toBe(200);
+  expect(response.headers.get('cache-control')).toBe('no-store');
+  const body = await response.json();
+  expect(body).toEqual({ format: 'flujo-local-instance-proof', version: 1, instanceId, origin, nonce,
+    proof: createHmac('sha256', token).update(`flujo-local-instance:v1\n${nonce}\n${instanceId}\n${origin}`).digest('base64url') });
+  expect(JSON.stringify(body)).not.toContain(token);
+});
+
+it.each<Record<string, string>>([
+  { origin: 'https://example.invalid' }, { host: 'example.invalid' }, { 'x-forwarded-for': '10.0.0.1' },
+])('rejects cross-origin, rebinding, and forwarded requests %j', async (headers) => {
+  expect(GET(request(headers)).status).toBe(403);
+});
+
+it('rejects network exposure, malformed challenges, and unregistered runtimes', () => {
+  process.env.FLUJO_EXPOSURE_MODE = 'network';
+  expect(GET(request()).status).toBe(403);
+  process.env.FLUJO_EXPOSURE_MODE = 'localhost';
+  expect(GET(request({}, 'bad')).status).toBe(400);
+  delete process.env.FLUJO_LOCAL_INSTANCE_ID;
+  expect(GET(request()).status).toBe(503);
+});

--- a/__tests__/workspace/routeCoverage.test.ts
+++ b/__tests__/workspace/routeCoverage.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 const APP_ROOT = path.join(process.cwd(), 'src', 'app');
 const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'] as const;
 const INSTALLATION_WIDE = new Set([
+  '/api/cloud/instance',
   '/api/network-exposure',
   '/api/runtime-environment',
   '/api/telemetry/daily-active',

--- a/__tests__/workspace/snapshotCoordinator.test.ts
+++ b/__tests__/workspace/snapshotCoordinator.test.ts
@@ -62,6 +62,15 @@ describe('snapshot coordinator cancellation and ownership', () => {
     delete process.env.FLUJO_SNAPSHOT_SESSION_TTL_MS;
   });
 
+  it('advertises worker compatibility in authenticated snapshot information', async () => {
+    const info = await snapshotCoordinator.info('compatibility');
+    expect(info.workerCompatibility).toMatchObject({
+      applicationVersion: expect.any(String), snapshotFormatVersion: 2,
+      layoutVersion: 2, workerProtocolVersion: 1,
+    });
+    expect(info.capability).toBe('available');
+  });
+
   it('reserves a workspace atomically for concurrent begin requests', async () => {
     const pendingCapture = deferred<CapturedWorkspaceSnapshot>();
     mockCapture.mockReturnValue(pendingCapture.promise);

--- a/__tests__/workspace/workerCompatibility.test.ts
+++ b/__tests__/workspace/workerCompatibility.test.ts
@@ -1,0 +1,33 @@
+import applicationPackage from '../../package.json';
+import { getWorkerCompatibility } from '@/backend/services/workspace/workerCompatibility';
+
+describe('worker image compatibility metadata', () => {
+  const originalRevision = process.env.FLUJO_BUILD_REVISION;
+
+  afterEach(() => {
+    if (originalRevision === undefined) delete process.env.FLUJO_BUILD_REVISION;
+    else process.env.FLUJO_BUILD_REVISION = originalRevision;
+  });
+
+  it('reports the implemented contract without claiming a checkout/build revision', () => {
+    delete process.env.FLUJO_BUILD_REVISION;
+    expect(getWorkerCompatibility()).toEqual({
+      applicationVersion: applicationPackage.version,
+      snapshotFormatVersion: 2,
+      layoutVersion: 2,
+      workerProtocolVersion: 1,
+    });
+  });
+
+  it('includes an explicit full build revision', () => {
+    process.env.FLUJO_BUILD_REVISION = 'a'.repeat(40);
+    expect(getWorkerCompatibility()).toMatchObject({ revision: 'a'.repeat(40) });
+  });
+
+  it.each(['abc1234', 'main', 'a'.repeat(39), 'a'.repeat(41), '../private', 'sensitive invalid value']) (
+    'omits malformed build revision metadata (%s)', (revision) => {
+      process.env.FLUJO_BUILD_REVISION = revision;
+      expect(getWorkerCompatibility()).not.toHaveProperty('revision');
+    },
+  );
+});

--- a/bin/flujo.mjs
+++ b/bin/flujo.mjs
@@ -100,12 +100,23 @@ const url = `http://localhost:${port}`;
 console.log(`[FLUJO] Starting on ${url} [exposure: ${env.FLUJO_EXPOSURE_MODE}]`);
 console.log(`[FLUJO] Data directory: ${process.env.FLUJO_DATA_DIR}`);
 
-const nextArgs = withExposureHostname(['start', '-p', String(port)], env);
+const { prepareLocalInstance, withLocalInstanceHostname } = await import(pathToFileURL(path.join(packageRoot, 'scripts', 'local-instance.mjs')).href);
+const nextArgs = withLocalInstanceHostname(withExposureHostname(['start', '-p', String(port)], env), env);
+let instance;
+try { instance = await prepareLocalInstance({ env, args: nextArgs, appRoot: packageRoot }); }
+catch {
+  console.error('[FLUJO] Could not prepare a private local instance.');
+  process.exit(1);
+}
 const child = spawn(process.execPath, [nextBin, ...nextArgs], {
   stdio: 'inherit',
   cwd: packageRoot,
-  env,
+  env: instance.env,
 });
+const registered = instance.register(child.pid).catch(() => {
+  console.error('[FLUJO] Could not register private local instance discovery.');
+});
+process.once('exit', instance.cleanup);
 
 let requestedSignal;
 let forceKillTimer;
@@ -113,6 +124,7 @@ let openerTimer;
 
 function forwardShutdown(signal) {
   requestedSignal ??= signal;
+  instance.cleanup();
   if (openerTimer) clearTimeout(openerTimer);
   if (child.exitCode !== null || child.signalCode !== null) return;
   try {
@@ -137,7 +149,9 @@ child.on('error', (error) => {
   process.exit(1);
 });
 
-child.on('exit', (code, signal) => {
+child.on('exit', async (code, signal) => {
+  await registered;
+  instance.cleanup();
   if (forceKillTimer) clearTimeout(forceKillTimer);
   const exitSignal = requestedSignal ?? signal;
   // Preserve signal semantics on POSIX after the child is gone. Windows does

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "!.next/dev/**",
     "public/**/*",
     "scripts/launch-next.mjs",
+    "scripts/local-instance.mjs",
     "scripts/healthcheck.mjs",
     "scripts/exclude-workspaces-from-next-glob.cjs",
     "scripts/exposure-mode.mjs",

--- a/scripts/launch-next.mjs
+++ b/scripts/launch-next.mjs
@@ -27,6 +27,7 @@ import { pathToFileURL } from 'node:url';
 import { createRequire } from 'node:module';
 import nextEnv from '@next/env';
 import { applyExposureRuntimeEnv, withExposureHostname } from './exposure-mode.mjs';
+import { prepareLocalInstance, withLocalInstanceHostname } from './local-instance.mjs';
 
 const require = createRequire(import.meta.url);
 const { loadEnvConfig } = nextEnv;
@@ -99,8 +100,38 @@ function withPort(args) {
   return hasPort ? [...args] : [...args, '-p', portFromNextArgs(args)];
 }
 
+/** Forward native launcher shutdown and remove only this launch's registration. */
+export function forwardNextShutdown(child, instance, registered, { parent = process, graceMs = 10_000 } = {}) {
+  let requestedSignal;
+  let forceKillTimer;
+  const forwardShutdown = (signal) => {
+    requestedSignal ??= signal;
+    instance.cleanup();
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    try { child.kill(signal); } catch { child.kill(); }
+    forceKillTimer ??= setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    }, graceMs);
+    forceKillTimer.unref();
+  };
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) parent.on(signal, () => forwardShutdown(signal));
+  parent.once('exit', instance.cleanup);
+  child.on('exit', async (code, signal) => {
+    await registered;
+    instance.cleanup();
+    if (forceKillTimer) clearTimeout(forceKillTimer);
+    const exitSignal = requestedSignal ?? signal;
+    if (exitSignal && parent.platform !== 'win32') {
+      parent.removeAllListeners(exitSignal);
+      parent.kill(parent.pid, exitSignal);
+      return;
+    }
+    parent.exit(code ?? (exitSignal ? 1 : 0));
+  });
+}
+
 /** Spawn `next <passthroughArgs>` with the TLS-configured env and forward its exit. */
-function launchNext(passthroughArgs) {
+async function launchNext(passthroughArgs) {
   const runtimeEnvDirectory = process.env.FLUJO_CONTAINER ? '/app/data' : process.cwd();
   process.env.FLUJO_RUNTIME_ENV_DIR = runtimeEnvDirectory;
   loadLaunchEnvironment(runtimeEnvDirectory, passthroughArgs[0] === 'dev');
@@ -110,7 +141,8 @@ function launchNext(passthroughArgs) {
     FLUJO_BASE_URL: process.env.FLUJO_BASE_URL || `http://127.0.0.1:${portFromNextArgs(passthroughArgs)}`,
   };
   const env = applyExposureRuntimeEnv(buildLaunchEnv(baseEnv), process.cwd());
-  const nextArgs = withExposureHostname(withPort(passthroughArgs), env);
+  const nextArgs = withLocalInstanceHostname(withExposureHostname(withPort(passthroughArgs), env), env);
+  const instance = await prepareLocalInstance({ env, args: nextArgs });
 
   const tlsSummary = [
     env.NODE_OPTIONS ? `NODE_OPTIONS="${env.NODE_OPTIONS}"` : null,
@@ -136,21 +168,18 @@ function launchNext(passthroughArgs) {
 
   const child = spawn(process.execPath, [nextBin, ...nextArgs], {
     stdio: 'inherit',
-    env,
+    env: instance.env,
   });
+  const registered = instance.register(child.pid).catch(() => {
+    console.error('[FLUJO] Could not register private local instance discovery.');
+  });
+  forwardNextShutdown(child, instance, registered);
 
   child.on('error', error => {
     console.error('[FLUJO] Failed to launch next:', error);
     process.exit(1);
   });
 
-  child.on('exit', (code, signal) => {
-    if (signal) {
-      process.kill(process.pid, signal);
-    } else {
-      process.exit(code ?? 0);
-    }
-  });
 }
 
 // Only launch when run directly (`node scripts/launch-next.mjs start -p 4200`), not when
@@ -158,5 +187,8 @@ function launchNext(passthroughArgs) {
 // Next.js command, e.g. ["start", "-p", "4200"].
 const isMain = import.meta.url === pathToFileURL(process.argv[1] ?? '').href;
 if (isMain) {
-  launchNext(process.argv.slice(2));
+  launchNext(process.argv.slice(2)).catch(() => {
+    console.error('[FLUJO] Could not prepare a private local instance.');
+    process.exitCode = 1;
+  });
 }

--- a/scripts/local-instance.mjs
+++ b/scripts/local-instance.mjs
@@ -1,0 +1,274 @@
+import { constants, promises as fs, lstatSync, unlinkSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createHmac, randomBytes, randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const runFile = promisify(execFile);
+const unsafe = () => new Error('Private storage is unavailable or has unsafe ownership, permissions, or links.');
+
+// Pass only the path/action in the child environment. No secret contents enter
+// PowerShell arguments, output, or error messages. ACLs are owner-only on Windows;
+// chmod(0600) alone would not restrict Windows readers.
+const windowsAclScript = String.raw`
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+try {
+  $p = [Environment]::GetEnvironmentVariable('FLUJO_PRIVATE_PATH')
+  $item = Get-Item -LiteralPath $p -Force
+  if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { throw 'unsafe' }
+  $sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
+  $acl = Get-Acl -LiteralPath $p
+  if ($acl.GetOwner([Security.Principal.SecurityIdentifier]).Value -ne $sid.Value) { throw 'unsafe' }
+  if ([Environment]::GetEnvironmentVariable('FLUJO_PRIVATE_ACTION') -eq 'protect') {
+    if ($item.PSIsContainer) {
+      $inherit = [Security.AccessControl.InheritanceFlags]'ContainerInherit, ObjectInherit'
+    } else {
+      $inherit = [Security.AccessControl.InheritanceFlags]::None
+    }
+    # Modify only the DACL. Replacing the entire descriptor or resetting its
+    # owner can require SeSecurityPrivilege on an already protected directory.
+    $acl.SetAccessRuleProtection($true, $false)
+    foreach ($oldRule in @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))) { $acl.RemoveAccessRuleSpecific($oldRule) }
+    $rule = [Security.AccessControl.FileSystemAccessRule]::new($sid, [Security.AccessControl.FileSystemRights]::FullControl, $inherit, [Security.AccessControl.PropagationFlags]::None, [Security.AccessControl.AccessControlType]::Allow)
+    $acl.SetAccessRule($rule)
+    # The PowerShell provider's Set-Acl can request SeSecurityPrivilege when
+    # reapplying a protected ACL. Persist only .NET's modified access section.
+    if ($item.PSIsContainer) { [IO.Directory]::SetAccessControl($p, $acl) } else { [IO.File]::SetAccessControl($p, $acl) }
+    $acl = Get-Acl -LiteralPath $p
+  }
+  if (-not $acl.AreAccessRulesProtected) { throw 'unsafe' }
+  $rules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))
+  if ($rules.Count -eq 0) { throw 'unsafe' }
+  foreach ($rule in $rules) {
+    if ($rule.IdentityReference.Value -ne $sid.Value -or $rule.AccessControlType -ne [Security.AccessControl.AccessControlType]::Allow) { throw 'unsafe' }
+    if (($rule.FileSystemRights -band [Security.AccessControl.FileSystemRights]::FullControl) -ne [Security.AccessControl.FileSystemRights]::FullControl) { throw 'unsafe' }
+  }
+  [Console]::Out.Write('private')
+} catch { [Environment]::Exit(1) }
+`;
+
+async function windowsAcl(filename, protect) {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  const executable = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+  try {
+    const { stdout } = await runFile(executable, ['-NoLogo', '-NoProfile', '-NonInteractive',
+      '-EncodedCommand', Buffer.from(windowsAclScript, 'utf16le').toString('base64')], {
+      windowsHide: true, timeout: 15_000, maxBuffer: 1024,
+      env: { SystemRoot: systemRoot, WINDIR: systemRoot,
+        FLUJO_PRIVATE_PATH: filename, FLUJO_PRIVATE_ACTION: protect ? 'protect' : 'check' },
+    });
+    if (stdout !== 'private') throw unsafe();
+  } catch { throw unsafe(); }
+}
+
+function plainDirectory(stat) { return stat.isDirectory() && !stat.isSymbolicLink(); }
+function owned(stat) { return process.platform === 'win32' || stat.uid === process.getuid(); }
+function sameFile(a, b) { return a.dev === b.dev && a.ino === b.ino && a.size === b.size && a.mtimeMs === b.mtimeMs; }
+
+async function directoryTree(directory, create) {
+  const resolved = path.resolve(directory);
+  const root = path.parse(resolved).root;
+  if (resolved === root) throw unsafe();
+  let current = root;
+  for (const segment of path.relative(root, resolved).split(path.sep)) {
+    current = path.join(current, segment);
+    let stat;
+    try { stat = await fs.lstat(current); }
+    catch (error) {
+      if (!create || error.code !== 'ENOENT') throw error;
+      try { await fs.mkdir(current, { mode: 0o700 }); }
+      catch (mkdirError) { if (mkdirError.code !== 'EEXIST') throw mkdirError; }
+      stat = await fs.lstat(current);
+    }
+    if (!plainDirectory(stat)) throw unsafe();
+  }
+  return resolved;
+}
+
+async function checkPrivate(filename, { directory = false, protect = false } = {}) {
+  const before = await fs.lstat(filename);
+  if (!owned(before) || before.isSymbolicLink()
+    || (directory ? !before.isDirectory() : !before.isFile() || before.nlink !== 1)) throw unsafe();
+  if (process.platform === 'win32') await windowsAcl(filename, protect);
+  else if (protect) await fs.chmod(filename, directory ? 0o700 : 0o600);
+  const after = await fs.lstat(filename);
+  if (before.dev !== after.dev || before.ino !== after.ino || after.isSymbolicLink()
+    || !owned(after) || (process.platform !== 'win32' && (after.mode & 0o077) !== 0)) throw unsafe();
+  return after;
+}
+
+export async function assertPrivateDirectory(directory) {
+  const resolved = await directoryTree(directory, false);
+  await checkPrivate(resolved, { directory: true });
+  return resolved;
+}
+
+export async function ensurePrivateDirectory(directory) {
+  try {
+    const resolved = await directoryTree(directory, true);
+    await checkPrivate(resolved, { directory: true, protect: true });
+    return resolved;
+  } catch { throw unsafe(); }
+}
+
+export async function readPrivateJson(filename, { maxBytes = 65536 } = {}) {
+  let handle;
+  try {
+    if (!Number.isSafeInteger(maxBytes) || maxBytes < 1 || maxBytes > 16 * 1024 * 1024) throw unsafe();
+    const resolved = path.resolve(filename);
+    await assertPrivateDirectory(path.dirname(resolved));
+    const before = await checkPrivate(resolved);
+    if (before.size > maxBytes) throw unsafe();
+    handle = await fs.open(resolved, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+    const opened = await handle.stat();
+    if (!sameFile(before, opened) || opened.nlink !== 1 || !opened.isFile()) throw unsafe();
+    const buffer = Buffer.alloc(before.size + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+      if (!bytesRead) break;
+      offset += bytesRead;
+    }
+    if (offset !== before.size || !sameFile(before, await handle.stat())) throw unsafe();
+    return JSON.parse(buffer.subarray(0, offset).toString('utf8'));
+  } catch (error) {
+    if (error.code === 'ENOENT') throw Object.assign(new Error('Private file was not found.'), { code: 'ENOENT' });
+    throw unsafe();
+  } finally { await handle?.close().catch(() => undefined); }
+}
+
+export async function writePrivateJson(filename, value, { exclusive = false } = {}) {
+  const resolved = path.resolve(filename);
+  let temporary;
+  let handle;
+  try {
+    await ensurePrivateDirectory(path.dirname(resolved));
+    try {
+      await checkPrivate(resolved);
+      if (exclusive) throw Object.assign(new Error('Private file already exists.'), { code: 'EEXIST' });
+    } catch (error) { if (error.code !== 'ENOENT') throw error; }
+    temporary = path.join(path.dirname(resolved), `.${path.basename(resolved)}.${randomUUID()}.tmp`);
+    handle = await fs.open(temporary, 'wx', 0o600);
+    await checkPrivate(temporary, { protect: true });
+    await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    if (exclusive) {
+      // link() publishes the completed file atomically and refuses replacement.
+      await fs.link(temporary, resolved);
+      await fs.unlink(temporary);
+    } else await fs.rename(temporary, resolved);
+    temporary = undefined;
+  } catch (error) {
+    if (error.code === 'EEXIST') throw Object.assign(new Error('Private file already exists.'), { code: 'EEXIST' });
+    throw unsafe();
+  } finally {
+    await handle?.close().catch(() => undefined);
+    if (temporary) await fs.unlink(temporary).catch(() => undefined);
+  }
+}
+
+export const LOCAL_INSTANCE_FORMAT = 'flujo-local-instance';
+const instanceIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const tokenPattern = /^[A-Za-z0-9._~+/=-]{32,}$/;
+
+export function localInstanceDirectory(env = process.env) {
+  return path.resolve(env.FLUJO_LOCAL_INSTANCE_DIR || path.join(os.homedir(), '.flujo', 'instances'));
+}
+
+function argument(args, long, short) {
+  const index = args.findIndex((arg) => arg === long || arg === short);
+  if (index >= 0) return args[index + 1];
+  return args.find((arg) => arg.startsWith(`${long}=`))?.slice(long.length + 1);
+}
+
+/** Use the same numeric loopback address for Next's bind and its advertised proof. */
+export function withLocalInstanceHostname(args, env) {
+  const normalized = [...args];
+  if (env.FLUJO_WORKER_MODE === '1' || env.FLUJO_CONTAINER || env.FLUJO_EXPOSURE_MODE !== 'localhost') return normalized;
+  for (let index = 0; index < normalized.length; index += 1) {
+    if ((normalized[index] === '--hostname' || normalized[index] === '-H') && normalized[index + 1] === 'localhost') {
+      normalized[index + 1] = '127.0.0.1';
+    } else if (normalized[index] === '--hostname=localhost') normalized[index] = '--hostname=127.0.0.1';
+  }
+  return normalized;
+}
+
+function nativeOrigin(env, args) {
+  if (env.FLUJO_WORKER_MODE === '1' || env.FLUJO_CONTAINER || env.FLUJO_EXPOSURE_MODE !== 'localhost') return null;
+  const hostname = argument(args, '--hostname', '-H') || '127.0.0.1';
+  if (!['127.0.0.1', '::1', '[::1]'].includes(hostname)) return null;
+  const port = Number(argument(args, '--port', '-p') || env.FLUJO_PORT || '4200');
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) throw new Error('Invalid local FLUJO instance port.');
+  return `http://${hostname.includes(':') ? '[::1]' : '127.0.0.1'}:${port}`;
+}
+
+/**
+ * Native launchers publish only after permissions are private and the child exists.
+ * @param {{ env?: Record<string, string | undefined>, args?: string[], appRoot?: string }} options
+ */
+export async function prepareLocalInstance({ env = process.env, args = [], appRoot = process.cwd() } = {}) {
+  const childEnv = { ...env };
+  delete childEnv.FLUJO_LOCAL_INSTANCE_ID;
+  delete childEnv.FLUJO_LOCAL_INSTANCE_ORIGIN;
+  const origin = nativeOrigin(childEnv, args);
+  if (!origin) return { env: childEnv, register: async () => undefined, cleanup: () => undefined };
+  const token = childEnv.FLUJO_SNAPSHOT_CONTROL_TOKEN?.trim() || randomBytes(32).toString('base64url');
+  if (!tokenPattern.test(token)) throw new Error('Local cloud control token must contain at least 32 URL-safe ASCII characters.');
+  const dataRoot = path.resolve(childEnv.FLUJO_PARENT_DATA_DIR?.trim() || childEnv.FLUJO_DATA_DIR?.trim() || appRoot);
+  const requestedDirectory = localInstanceDirectory(childEnv);
+  const workspaceRelative = path.relative(path.join(dataRoot, 'workspaces'), requestedDirectory);
+  if (workspaceRelative === '' || (!workspaceRelative.startsWith('..') && !path.isAbsolute(workspaceRelative))) {
+    throw new Error('Local instance discovery must remain outside workspace snapshots.');
+  }
+  const directory = await ensurePrivateDirectory(requestedDirectory);
+  const instanceId = randomUUID();
+  childEnv.FLUJO_LOCAL_INSTANCE_ID = instanceId;
+  childEnv.FLUJO_LOCAL_INSTANCE_ORIGIN = origin;
+  childEnv.FLUJO_SNAPSHOT_CONTROL_TOKEN = token;
+  const filename = path.join(directory, `${instanceId}.json`);
+  let identity;
+  let closed = false;
+  const cleanup = () => {
+    closed = true;
+    if (!identity) return;
+    try {
+      const current = lstatSync(filename);
+      if (current.dev === identity.dev && current.ino === identity.ino && current.isFile()
+        && !current.isSymbolicLink() && current.nlink === 1) unlinkSync(filename);
+    } catch { /* stale records are harmless: discovery requires a fresh proof */ }
+  };
+  return {
+    env: childEnv,
+    async register(pid) {
+      if (closed) return;
+      if (!Number.isSafeInteger(pid) || pid <= 0) throw new Error('Local FLUJO child did not start.');
+      await writePrivateJson(filename, {
+        format: LOCAL_INSTANCE_FORMAT, version: 1, instanceId, pid,
+        origin, appRoot: path.resolve(appRoot), dataRoot, token,
+      }, { exclusive: true });
+      identity = await fs.lstat(filename);
+      if (closed) cleanup();
+    },
+    cleanup,
+  };
+}
+
+/**
+ * Public challenge response, authenticated with a proof rather than a disclosed bearer.
+ * @param {string} nonce
+ * @param {Record<string, string | undefined>} env
+ */
+export function createLocalInstanceProof(nonce, env = process.env) {
+  const instanceId = env.FLUJO_LOCAL_INSTANCE_ID;
+  const origin = env.FLUJO_LOCAL_INSTANCE_ORIGIN;
+  const token = env.FLUJO_SNAPSHOT_CONTROL_TOKEN?.trim();
+  if (env.FLUJO_WORKER_MODE === '1' || env.FLUJO_CONTAINER || !instanceIdPattern.test(instanceId || '')
+    || !/^http:\/\/(127\.0\.0\.1|\[::1\]):[1-9][0-9]{0,4}$/.test(origin || '') || !tokenPattern.test(token || '')) return null;
+  if (typeof nonce !== 'string' || !/^[a-f0-9]{64}$/.test(nonce)) throw new Error('Invalid instance challenge.');
+  const proof = createHmac('sha256', token).update(`flujo-local-instance:v1\n${nonce}\n${instanceId}\n${origin}`).digest('base64url');
+  return { format: 'flujo-local-instance-proof', version: 1, instanceId, origin, nonce, proof };
+}

--- a/scripts/smoke-cloud-worker.mjs
+++ b/scripts/smoke-cloud-worker.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/** Real Next/engine smoke test. Uses private temp data and a loopback mock model only. */
+/** Real Next/engine/MCP smoke. --production tests the packaged Docker application. */
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { createCipheriv, createHash, randomBytes } from 'node:crypto';
@@ -10,16 +10,22 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { setTimeout as delay } from 'node:timers/promises';
 import JSZip from 'jszip';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { checkHealth } from './healthcheck.mjs';
 
 const application = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const production = process.argv.includes('--production');
+if (process.argv.slice(2).some(argument => argument !== '--production')) throw new Error('Usage: smoke-cloud-worker.mjs [--production]');
 const packageJson = JSON.parse(await fs.readFile(path.join(application, 'package.json'), 'utf8'));
 const root = await fs.mkdtemp(path.join(os.tmpdir(), 'flujo-cloud-worker-smoke-'));
-const runtimeApplication = path.join(root, 'application');
+const runtimeApplication = production ? application : path.join(root, 'application');
 const overlayLinks = ['public', 'mcp-servers', 'node_modules', 'scripts'];
 const workspace = 'cloud-smoke';
 const conversationId = 'cloud-smoke-conversation';
 const answer = 'cloud-worker-smoke-response';
+const sourceWorkspaceRoot = 'C:\\synthetic-source\\workspaces\\cloud-smoke';
+const sourceFilesystemRoot = `${sourceWorkspaceRoot}\\mcp-servers\\filesystem`;
 const subtrees = ['db', 'mcp-servers', 'userdata', 'snapshots', 'screenshots', 'recordings', 'browser-profile', 'bash-utils', 'artifacts'];
 const controlToken = randomBytes(32).toString('hex');
 const key = randomBytes(32);
@@ -95,7 +101,8 @@ function safeEnvironment() {
   for (const [name, value] of Object.entries(process.env)) {
     if (/^(path|systemroot|windir|comspec|pathext|systemdrive|programfiles(?:\(x86\))?)$/i.test(name) && value) safe[name] = value;
   }
-  return { ...safe, NODE_ENV: 'development', NEXT_TELEMETRY_DISABLED: '1',
+  return { ...safe, NODE_ENV: production ? 'production' : 'development', NEXT_TELEMETRY_DISABLED: '1',
+    ...(production ? { FLUJO_CONTAINER: '1', FLUJO_BUILD_REVISION: process.env.FLUJO_BUILD_REVISION } : {}),
     HOME: path.join(root, 'home'), USERPROFILE: path.join(root, 'home'),
     TMP: path.join(root, 'temp'), TEMP: path.join(root, 'temp'), TMPDIR: path.join(root, 'temp') };
 }
@@ -103,11 +110,15 @@ function safeEnvironment() {
 async function startWorker(port, archivePath, archiveHash, harness) {
   childLog = '';
   const sandboxPort = await unusedPort();
-  child = spawn(process.execPath, [harness], {
+  const args = production
+    ? [path.join(application, 'scripts', 'launch-next.mjs'), 'start', '-p', String(port), '-H', '127.0.0.1']
+    : [harness];
+  child = spawn(process.execPath, args, {
     cwd: runtimeApplication, windowsHide: true, detached: process.platform !== 'win32', stdio: ['ignore', 'pipe', 'pipe'],
     env: { ...safeEnvironment(), FLUJO_WORKER_MODE: '1', FLUJO_WORKER_SNAPSHOT: archivePath,
       FLUJO_WORKER_SNAPSHOT_SHA256: archiveHash, FLUJO_WORKER_SNAPSHOT_KEY: key.toString('base64'),
       FLUJO_SNAPSHOT_CONTROL_TOKEN: controlToken, FLUJO_DATA_DIR: path.join(root, 'data'),
+      FLUJO_APP_ROOT: runtimeApplication,
       FLUJO_PORT: String(port), FLUJO_BASE_URL: `http://127.0.0.1:${port}`,
       FLUJO_MCP_APP_SANDBOX_PORT: String(sandboxPort), FLUJO_MCP_APP_SANDBOX_HOST: '127.0.0.1',
       FLUJO_EXPOSURE_MODE: 'localhost', SMOKE_PORT: String(port) },
@@ -139,17 +150,19 @@ try {
   // Next's programmatic custom server ignores conf.distDir in dev startup.
   // A private app overlay keeps its cache/lock/config writes away from any
   // concurrently running user server, without copying dependencies or secrets.
-  await fs.mkdir(runtimeApplication);
-  // Next's route discovery does not walk a junctioned src directory on Windows.
-  // Copy only repository source code; runtime workspaces and .env files are absent.
-  await fs.cp(path.join(application, 'src'), path.join(runtimeApplication, 'src'), { recursive: true });
-  for (const name of ['package.json', 'package-lock.json', 'next.config.mjs', 'tsconfig.json', 'next-env.d.ts',
-    'postcss.config.mjs', 'postcss.config.js', 'tailwind.config.ts', 'tailwind.config.js']) {
-    try { await fs.copyFile(path.join(application, name), path.join(runtimeApplication, name)); }
-    catch (error) { if (error.code !== 'ENOENT') throw error; }
-  }
-  for (const name of overlayLinks) {
-    await fs.symlink(path.join(application, name), path.join(runtimeApplication, name), process.platform === 'win32' ? 'junction' : 'dir');
+  if (!production) {
+    await fs.mkdir(runtimeApplication);
+    // Next's route discovery does not walk a junctioned src directory on Windows.
+    // Copy only repository source code; runtime workspaces and .env files are absent.
+    await fs.cp(path.join(application, 'src'), path.join(runtimeApplication, 'src'), { recursive: true });
+    for (const name of ['package.json', 'package-lock.json', 'next.config.mjs', 'tsconfig.json', 'next-env.d.ts',
+      'postcss.config.mjs', 'postcss.config.js', 'tailwind.config.ts', 'tailwind.config.js']) {
+      try { await fs.copyFile(path.join(application, name), path.join(runtimeApplication, name)); }
+      catch (error) { if (error.code !== 'ENOENT') throw error; }
+    }
+    for (const name of overlayLinks) {
+      await fs.symlink(path.join(application, name), path.join(runtimeApplication, name), process.platform === 'win32' ? 'junction' : 'dir');
+    }
   }
   const modelPort = await listen(modelServer);
   const workerPort = await unusedPort();
@@ -159,9 +172,15 @@ try {
     sourceHandle: `${source.type}-bottom`, targetHandle: `${target.type}-top`, type: 'custom', data: { edgeType: 'standard' } });
   const flow = { id: 'smoke-flow', name: 'CloudSmoke', nodes, edges: [edge(nodes[0], nodes[1]), edge(nodes[1], nodes[2])], updatedAt: Date.now() };
   const files = {
-    'db/mcp_servers.json': '{}',
+    'db/mcp_servers.json': JSON.stringify({ filesystem: {
+      name: 'filesystem', transport: 'stdio', command: 'node',
+      args: [`${sourceFilesystemRoot}\\dist\\index.js`], rootPath: sourceFilesystemRoot,
+      env: {}, roots: [`${sourceWorkspaceRoot}\\userdata`], disabled: false,
+      exposeAsMcpServer: true, source: { type: 'marketplace', id: '@mario.andreschak/mcp-filesystem' },
+    } }),
     'db/models.json': JSON.stringify([{ id: 'smoke-model', name: 'cloud-smoke-model', provider: 'openai', adapter: 'openai', ApiKey: 'synthetic-smoke-key', baseUrl: `http://127.0.0.1:${modelPort}/v1` }]),
     'db/flows/smoke-flow.json': JSON.stringify(flow),
+    'userdata/mcp-smoke-input.txt': 'restored filesystem smoke input',
   };
   const zip = new JSZip();
   for (const [name, content] of Object.entries(files)) zip.file(name, content);
@@ -169,7 +188,8 @@ try {
     createdAt: new Date().toISOString(), coherence: 'registered-flujo-writers', externalRootsIncluded: false, subtrees,
     files: Object.entries(files).map(([name, content]) => ({ path: name, size: Buffer.byteLength(content), sha256: sha256(content) })),
     source: { version: packageJson.version, platform: process.platform },
-    runtime: { codexAuth: 'none', encryption: 'default', mcpTransfer: { formatVersion: 1, sourceWorkspaceRoot: '/synthetic-source', servers: [] } },
+    runtime: { codexAuth: 'none', encryption: 'default', mcpTransfer: { formatVersion: 1, sourceWorkspaceRoot,
+      servers: [{ name: 'filesystem', kind: 'bundled', sourceRootPath: sourceFilesystemRoot }] } },
   }));
   const plaintext = await zip.generateAsync({ type: 'nodebuffer' });
   const iv = randomBytes(12);
@@ -179,7 +199,7 @@ try {
   await fs.writeFile(archivePath, JSON.stringify({ format: 'flujo-workspace-encrypted', version: 1, iv: iv.toString('base64'),
     tag: cipher.getAuthTag().toString('base64'), data: data.toString('base64') }), { mode: 0o600 });
   const harness = path.join(root, 'next-harness.mjs');
-  await fs.writeFile(harness, `import {createRequire} from 'node:module';
+  if (!production) await fs.writeFile(harness, `import {createRequire} from 'node:module';
 import http from 'node:http';
 const require=createRequire(${JSON.stringify(path.join(runtimeApplication, 'package.json'))});
 const next=require('next');
@@ -189,15 +209,43 @@ await app.prepare();
 const server=http.createServer((req,res)=>handler(req,res));
 server.listen(Number(process.env.SMOKE_PORT),'127.0.0.1');
 `);
-  console.log('Starting isolated Next worker with an encrypted synthetic snapshot...');
+  console.log(`Starting ${production ? 'packaged production' : 'isolated development'} worker with an encrypted synthetic snapshot...`);
   const ready = await startWorker(workerPort, archivePath, sha256(plaintext), harness);
   assert.equal(ready.workspace, workspace);
+  assert.deepEqual(ready.servers, [{ name: 'filesystem', status: 'ready' }]);
   assert.equal(await checkHealth({ env: { FLUJO_WORKER_MODE: '1', FLUJO_SNAPSHOT_CONTROL_TOKEN: controlToken, FLUJO_PORT: String(workerPort) } }), true);
   assert.equal(await checkHealth({ env: { FLUJO_WORKER_MODE: '1', FLUJO_SNAPSHOT_CONTROL_TOKEN: 'incorrect-synthetic-token', FLUJO_PORT: String(workerPort) } }), false);
   assert.equal(providerCalls, 0, 'Bootstrap must not execute flows.');
-  for (const route of ['/api/worker/status', '/api/env', '/v1/chat/completions', '/mcp-flows']) {
+  for (const route of ['/api/worker/status', '/api/env', '/api/snapshot/info', '/v1/chat/completions', '/mcp-flows', '/mcp-proxy/filesystem']) {
     const result = await fetch(`http://127.0.0.1:${workerPort}${route}`, { signal: AbortSignal.timeout(15_000) });
     assert.equal(result.status, 401, `Unauthenticated ${route} must be denied.`);
+  }
+  const infoResponse = await fetch(`http://127.0.0.1:${workerPort}/api/snapshot/info?workspace=${workspace}`, {
+    headers: { authorization: `Bearer ${controlToken}` }, signal: AbortSignal.timeout(15_000),
+  });
+  assert.equal(infoResponse.status, 200);
+  const info = await infoResponse.json();
+  assert.deepEqual(info.workerCompatibility, {
+    applicationVersion: packageJson.version, snapshotFormatVersion: 2, layoutVersion: 2, workerProtocolVersion: 1,
+    ...(production && /^[a-f0-9]{40}$/.test(process.env.FLUJO_BUILD_REVISION ?? '') ? { revision: process.env.FLUJO_BUILD_REVISION } : {}),
+  });
+  const filesystem = new Client({ name: 'flujo-worker-smoke', version: '1.0.0' }, { capabilities: {} });
+  try {
+    await filesystem.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${workerPort}/mcp-proxy/filesystem?workspace=${workspace}`), {
+      requestInit: { headers: { authorization: `Bearer ${controlToken}` } },
+    }));
+    const targetRoot = path.join(root, 'data', 'workspaces', workspace, 'userdata');
+    const allowed = await filesystem.callTool({ name: 'get_allowed_directories', arguments: {} });
+    assert.notEqual(allowed.isError, true);
+    assert.ok(allowed.structuredContent?.directories?.includes(targetRoot), 'MCP roots must move from the Windows snapshot to this worker.');
+    const read = await filesystem.callTool({ name: 'read_file', arguments: { path: path.join(targetRoot, 'mcp-smoke-input.txt') } });
+    assert.notEqual(read.isError, true);
+    assert.ok(JSON.stringify(read).includes('restored filesystem smoke input'));
+    const written = await filesystem.callTool({ name: 'write_file', arguments: { path: path.join(targetRoot, 'mcp-smoke-output.txt'), content: 'worker MCP write succeeded' } });
+    assert.notEqual(written.isError, true);
+    assert.equal(await fs.readFile(path.join(targetRoot, 'mcp-smoke-output.txt'), 'utf8'), 'worker MCP write succeeded');
+  } finally {
+    await filesystem.close();
   }
   const result = await fetch(`http://127.0.0.1:${workerPort}/v1/chat/completions?workspace=${workspace}`, {
     method: 'POST', headers: { authorization: `Bearer ${controlToken}`, 'content-type': 'application/json' },
@@ -219,8 +267,9 @@ server.listen(Number(process.env.SMOKE_PORT),'127.0.0.1');
   await stopChild();
   await startWorker(workerPort, archivePath, sha256(plaintext), harness);
   assert.equal(await fs.readFile(conversationFile, 'utf8'), saved, 'Restart must preserve worker results.');
+  assert.equal(await fs.readFile(path.join(root, 'data', 'workspaces', workspace, 'userdata', 'mcp-smoke-output.txt'), 'utf8'), 'worker MCP write succeeded');
   assert.equal(providerCalls, callsBeforeRestart, 'Restart must not replay the completed flow.');
-  console.log('PASS: encrypted restore, private ingress, real ExecutionEngine/model dispatch, unattended flow, and restart preservation.');
+  console.log('PASS: encrypted restore, compatibility metadata, private ingress, restored MCP read/write, real ExecutionEngine/model dispatch, unattended flow, and restart preservation.');
 } catch (error) {
   console.error(error.stack ?? error.message);
   if (childLog) console.error(childLog.slice(-16_000));
@@ -231,7 +280,7 @@ server.listen(Number(process.env.SMOKE_PORT),'127.0.0.1');
   await new Promise(resolve => modelServer.close(resolve));
   const expectedPrefix = path.join(os.tmpdir(), 'flujo-cloud-worker-smoke-');
   if (!path.resolve(root).startsWith(path.resolve(expectedPrefix))) throw new Error('Refusing unsafe smoke cleanup path.');
-  for (const name of overlayLinks) {
+  for (const name of production ? [] : overlayLinks) {
     const link = path.join(runtimeApplication, name);
     const stat = await fs.lstat(link).catch(error => { if (error.code === 'ENOENT') return null; throw error; });
     if (stat?.isSymbolicLink()) await fs.unlink(link);

--- a/src/app/api/cloud/instance/route.ts
+++ b/src/app/api/cloud/instance/route.ts
@@ -1,0 +1,18 @@
+import { assertLocalRequest } from '@/utils/http/localRequest';
+import { createLocalInstanceProof } from '../../../../../scripts/local-instance.mjs';
+
+// FLUJO_INSTALLATION_WIDE_ROUTE: discovery must work while workspace storage is locked or migrating.
+export const runtime = 'nodejs';
+
+export function GET(request: Request): Response {
+  const forbidden = assertLocalRequest(request, { strictLoopback: true });
+  if (forbidden) return forbidden;
+  const headers = { 'Cache-Control': 'no-store' };
+  const nonce = new URL(request.url).searchParams.get('nonce');
+  if (!nonce || !/^[a-f0-9]{64}$/.test(nonce)) {
+    return Response.json({ error: 'Invalid instance challenge.' }, { status: 400, headers });
+  }
+  const proof = createLocalInstanceProof(nonce);
+  return proof ? Response.json(proof, { headers })
+    : Response.json({ error: 'Local instance discovery is unavailable.' }, { status: 503, headers });
+}

--- a/src/backend/services/workspace/snapshotArchive.ts
+++ b/src/backend/services/workspace/snapshotArchive.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import JSZip from 'jszip';
 import { WORKSPACE_SUBTREES, getWorkspaceDataDir } from '@/utils/workspace';
 import { WORKSPACE_LAYOUT_VERSION } from './layoutVersion';
+import { WORKER_SNAPSHOT_FORMAT_VERSION } from './workerCompatibility';
 import { addFolderToZipLinkSafe } from './backupRestoreFs';
 import { buildWorkspaceMcpTransferPlan, pinWorkspaceMcpTransferPlan, selectWorkspaceFlowDependencies, type WorkspaceMcpTransferPlan } from '@/backend/services/packages/workspaceMcpTransfer';
 import { CODEX_AUTH_SOURCE_FILE, WORKSPACE_CODEX_AUTH_SOURCE, readCodexAuthForTransfer } from '@/backend/services/model/adapters/codexAuth';
@@ -26,7 +27,7 @@ export interface SnapshotManifestFile {
 }
 
 export interface WorkspaceSnapshotManifest {
-  formatVersion: 2;
+  formatVersion: typeof WORKER_SNAPSHOT_FORMAT_VERSION;
   layoutVersion: number;
   workspace: string;
   generation: number;
@@ -345,7 +346,7 @@ export async function captureWorkspaceSnapshot(
 
   files.sort((left, right) => left.path.localeCompare(right.path));
   const manifest: WorkspaceSnapshotManifest = {
-    formatVersion: 2,
+    formatVersion: WORKER_SNAPSHOT_FORMAT_VERSION,
     layoutVersion: WORKSPACE_LAYOUT_VERSION,
     workspace,
     generation,

--- a/src/backend/services/workspace/snapshotCoordinator.ts
+++ b/src/backend/services/workspace/snapshotCoordinator.ts
@@ -16,6 +16,7 @@ import {
   type WorkspaceSnapshotBoundary,
 } from './workspaceMutationGate';
 import { WORKSPACE_LAYOUT_VERSION } from './layoutVersion';
+import { getWorkerCompatibility, type WorkerCompatibility } from './workerCompatibility';
 
 const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
 const MAX_SESSION_TTL_MS = 60 * 60 * 1000;
@@ -258,6 +259,7 @@ export const snapshotCoordinator = {
   async info(workspace = getCurrentWorkspace()): Promise<{
     workspace: string;
     layoutVersion: number;
+    workerCompatibility: WorkerCompatibility;
     capability: 'available' | 'busy';
     coherence: 'registered-flujo-writers';
     externalRootsIncluded: false;
@@ -270,6 +272,7 @@ export const snapshotCoordinator = {
     return {
       workspace: normalizedWorkspace,
       layoutVersion: WORKSPACE_LAYOUT_VERSION,
+      workerCompatibility: getWorkerCompatibility(),
       capability: active || mutation.blocked ? 'busy' : 'available',
       coherence: 'registered-flujo-writers',
       externalRootsIncluded: false,

--- a/src/backend/services/workspace/snapshotRestore.ts
+++ b/src/backend/services/workspace/snapshotRestore.ts
@@ -13,6 +13,7 @@ import type { WorkspaceMcpTransferPlan } from '@/backend/services/packages/works
 import { isChatGptAuthCache } from '@/backend/services/model/adapters/codexAuth';
 import { atomicWriteWithoutLinks } from './backupRestoreFs';
 import { WORKSPACE_LAYOUT_VERSION } from './layoutVersion';
+import { WORKER_SNAPSHOT_FORMAT_VERSION } from './workerCompatibility';
 import { isWorkerMode, setWorkerBootstrapStatus } from './workerMode';
 
 const MANIFEST_PATH = 'snapshot-manifest.json';
@@ -151,7 +152,7 @@ function inspectArchive(bytes: Buffer, maxFileBytes: number, maxBytes: number): 
 }
 
 function validateManifest(value: unknown): WorkerManifest {
-  if (!record(value) || value.formatVersion !== 2 || value.layoutVersion !== WORKSPACE_LAYOUT_VERSION
+  if (!record(value) || value.formatVersion !== WORKER_SNAPSHOT_FORMAT_VERSION || value.layoutVersion !== WORKSPACE_LAYOUT_VERSION
       || value.externalRootsIncluded !== false || !record(value.source)
       || value.source.version !== applicationPackage.version || typeof value.source.platform !== 'string'
       || !record(value.runtime) || !record(value.runtime.mcpTransfer)

--- a/src/backend/services/workspace/workerCompatibility.ts
+++ b/src/backend/services/workspace/workerCompatibility.ts
@@ -1,0 +1,28 @@
+import applicationPackage from '../../../../package.json';
+import { WORKSPACE_LAYOUT_VERSION } from './layoutVersion';
+
+/** Change the protocol when the worker control/restore contract becomes incompatible. */
+export const WORKER_PROTOCOL_VERSION = 1;
+export const WORKER_SNAPSHOT_FORMAT_VERSION = 2;
+
+export interface WorkerCompatibility {
+  applicationVersion: string;
+  snapshotFormatVersion: typeof WORKER_SNAPSHOT_FORMAT_VERSION;
+  layoutVersion: typeof WORKSPACE_LAYOUT_VERSION;
+  workerProtocolVersion: typeof WORKER_PROTOCOL_VERSION;
+  revision?: string;
+}
+
+export function getWorkerCompatibility(): WorkerCompatibility {
+  // Official images bake this value into their build environment. Do not infer
+  // an application's compiled revision from its current git checkout: it may
+  // be dirty, switched after building, or absent in an npm installation.
+  const revision = process.env.FLUJO_BUILD_REVISION;
+  return {
+    applicationVersion: applicationPackage.version,
+    snapshotFormatVersion: WORKER_SNAPSHOT_FORMAT_VERSION,
+    layoutVersion: WORKSPACE_LAYOUT_VERSION,
+    workerProtocolVersion: WORKER_PROTOCOL_VERSION,
+    ...(/^[a-f0-9]{40}$/.test(revision ?? '') ? { revision } : {}),
+  };
+}


### PR DESCRIPTION
Native FLUJO now advertises its actual loopback address and data root through a private per-launch registry. A controller verifies a fresh HMAC challenge before using the local control credential, so cloud deployment can discover a nondefault port without asking users to configure tokens or installation paths.

Snapshot info now exposes application, snapshot, workspace-layout and worker-protocol compatibility. The official Docker image records matching OCI labels. A new main-branch workflow builds an amd64 worker, exercises encrypted restore, bundled MCP operations, the existing flow engine and restart persistence in an offline production container, then publishes the same tested image to dedicated `cloud-worker` channels. Release `latest` keeps its existing release workflow.

Validation completed: 19 local-instance tests, 12 related launcher/settings tests, 40 snapshot/compatibility tests, TypeScript and touched-file ESLint. The separate bridge's final hosted CI passes on Windows and Linux; Windows runs all 110 tests with real private ACLs. Live native discovery on port 43450 and authenticated workspace metadata passed without either controller token configured; unauthenticated snapshot access returns 401.

The first CI run passed lint, TypeScript and all installer checks. Its main suite reported6627 passed/16 failed:14 failures match main3cae8225 byte-for-byte, one inode-reuse failure matches a historical main run with unchanged source, and the new discovery route was missing from the route-coverage test allowlist. The final commit fixes that classification;75 focused route/security/conversation tests and touched-file lint pass afterward. Isolated CI reports73 passed/1 failed, identical to main. Full-suite green is not claimed.

The production image gate passed in [workflow run 33999689534](https://github.com/mario-andreschak/FLUJO/actions/runs/33999689534), after PR508 corrected the synthetic fixture to opt into restricted filesystem roots. The tested image was published to GHCR at `sha256:8b5da896c92be52aadd0ad866cf2821d780d81249b9a3a29de80a7b46a0cb709`. Its smoke verifies encrypted restore, MCP paths/read/write, real ExecutionEngine dispatch using a local mock model, authenticated ingress and restart persistence before publishing. No real credentials or workspace data enter that image test. A live managed CLI deployment selected this official image automatically and completed Astra, GitHub MCP and filesystem operations with the local source stopped. PR509 subsequently fixes elevated Windows private-storage handling without relaxing private reads.

The CLI/controller changes are maintained in the separate private `flujo-app/flujo-cloud` repository. Native discovery covers git/npm launches in localhost mode. Existing container/operator deployments retain their explicit control-token path.
