### PR TITLE
Enable the intended filesystem restriction in worker smoke

### DIFF
--- a/scripts/smoke-cloud-worker.mjs
+++ b/scripts/smoke-cloud-worker.mjs
@@ -172,6 +172,9 @@ try {
     sourceHandle: `${source.type}-bottom`, targetHandle: `${target.type}-top`, type: 'custom', data: { edgeType: 'standard' } });
   const flow = { id: 'smoke-flow', name: 'CloudSmoke', nodes, edges: [edge(nodes[0], nodes[1]), edge(nodes[1], nodes[2])], updatedAt: Date.now() };
   const files = {
+    // Configured MCP roots are an opt-in restriction; enable it so the smoke
+    // verifies Windows-to-worker root remapping instead of the default host root.
+    'db/speech_settings.json': JSON.stringify({ experimental: { restrictMcpFilesystemToRoots: true } }),
     'db/mcp_servers.json': JSON.stringify({ filesystem: {
       name: 'filesystem', transport: 'stdio', command: 'node',
       args: [`${sourceFilesystemRoot}\\dist\\index.js`], rootPath: sourceFilesystemRoot,


### PR DESCRIPTION
The first official worker-image smoke reached authenticated readiness but failed its expected MCP-root assertion: the synthetic workspace set filesystem roots without enabling FLUJO's opt-in root restriction, so the filesystem server correctly reported the unrestricted Linux root.

Include the existing experimental root-restriction setting in the synthetic snapshot. Keep the strict Windows-to-Linux remapping assertion and real MCP read/write checks unchanged. This changes only the test fixture; the publishing workflow still refuses to publish until the full offline production smoke passes.

Validation:13 filesystem-roots tests, script syntax, ESLint and a synthetic ZIP round-trip passed. The initial failed publishing run skipped all publication steps; the next main run will rebuild and test the corrected fixture before advancing the worker channel.
