### PR TITLE
Fix private instance discovery on elevated Windows hosts

### DIFF
--- a/scripts/local-instance.mjs
+++ b/scripts/local-instance.mjs
@@ -16,28 +16,41 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 try {
   $p = [Environment]::GetEnvironmentVariable('FLUJO_PRIVATE_PATH')
-  $item = Get-Item -LiteralPath $p -Force
-  if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { throw 'unsafe' }
-  $sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
-  $acl = Get-Acl -LiteralPath $p
-  if ($acl.GetOwner([Security.Principal.SecurityIdentifier]).Value -ne $sid.Value) { throw 'unsafe' }
-  if ([Environment]::GetEnvironmentVariable('FLUJO_PRIVATE_ACTION') -eq 'protect') {
-    if ($item.PSIsContainer) {
+  # Avoid filesystem-provider cmdlet initialization: Get-Item can stall on a
+  # hosted Windows runner with this deliberately reduced child environment.
+  $attributes = [IO.File]::GetAttributes($p)
+  if (($attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { throw 'unsafe' }
+  $isDirectory = ($attributes -band [IO.FileAttributes]::Directory) -ne 0
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $sid = $identity.User
+  $acl = if ($isDirectory) { [IO.Directory]::GetAccessControl($p) } else { [IO.File]::GetAccessControl($p) }
+  $owner = $acl.GetOwner([Security.Principal.SecurityIdentifier])
+  $protect = [Environment]::GetEnvironmentVariable('FLUJO_PRIVATE_ACTION') -eq 'protect'
+  if ($owner.Value -ne $sid.Value) {
+    # Elevated Windows processes can create files owned by their token's
+    # default owner (Administrators). Normalize only that exact token owner
+    # while protecting; existing private-file reads still require the user.
+    if (-not $protect -or $owner.Value -ne $identity.Owner.Value) { throw 'unsafe' }
+    $acl.SetOwner($sid)
+  }
+  if ($protect) {
+    if ($isDirectory) {
       $inherit = [Security.AccessControl.InheritanceFlags]'ContainerInherit, ObjectInherit'
     } else {
       $inherit = [Security.AccessControl.InheritanceFlags]::None
     }
-    # Modify only the DACL. Replacing the entire descriptor or resetting its
-    # owner can require SeSecurityPrivilege on an already protected directory.
+    # Modify the DACL and, only when needed above, its effective token owner.
+    # Do not replace the full security descriptor or request its audit section.
     $acl.SetAccessRuleProtection($true, $false)
     foreach ($oldRule in @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))) { $acl.RemoveAccessRuleSpecific($oldRule) }
     $rule = [Security.AccessControl.FileSystemAccessRule]::new($sid, [Security.AccessControl.FileSystemRights]::FullControl, $inherit, [Security.AccessControl.PropagationFlags]::None, [Security.AccessControl.AccessControlType]::Allow)
     $acl.SetAccessRule($rule)
     # The PowerShell provider's Set-Acl can request SeSecurityPrivilege when
-    # reapplying a protected ACL. Persist only .NET's modified access section.
-    if ($item.PSIsContainer) { [IO.Directory]::SetAccessControl($p, $acl) } else { [IO.File]::SetAccessControl($p, $acl) }
-    $acl = Get-Acl -LiteralPath $p
+    # reapplying a protected ACL. Persist only .NET's modified sections.
+    if ($isDirectory) { [IO.Directory]::SetAccessControl($p, $acl) } else { [IO.File]::SetAccessControl($p, $acl) }
+    $acl = if ($isDirectory) { [IO.Directory]::GetAccessControl($p) } else { [IO.File]::GetAccessControl($p) }
   }
+  if ($acl.GetOwner([Security.Principal.SecurityIdentifier]).Value -ne $sid.Value) { throw 'unsafe' }
   if (-not $acl.AreAccessRulesProtected) { throw 'unsafe' }
   $rules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))
   if ($rules.Count -eq 0) { throw 'unsafe' }


### PR DESCRIPTION
Native instance discovery could fail on hosted or elevated Windows: filesystem-provider initialization could hang in the deliberately minimal PowerShell environment, and newly created paths could belong to the token's default owner (Administrators).

Use direct .NET filesystem and ACL operations. During protection, normalize ownership only when it matches the current token's default owner; existing reads still require the exact user owner. Recheck user ownership and the protected, user-only DACL after applying changes. Secret contents never enter child arguments or diagnostics.

Validation: 19 local-instance/challenge tests, five real Windows filesystem/ACL tests against the core helper, full typecheck, touched-file lint, syntax, and diff checks passed. The shared helper matches the bridge implementation that passed all 110 tests on hosted Windows and Linux, including elevated ownership normalization and refusal of group-owned private reads.
CI follow-up: [PR run 34000998564](https://github.com/mario-andreschak/FLUJO/actions/runs/34000998564) passed lint and typecheck. The main suite finished with 6,629 passed / 14 failed; every failing test also failed on the immediate parent main revision c55ce441 ([baseline run 33999689518](https://github.com/mario-andreschak/FLUJO/actions/runs/33999689518), 6,628 passed / 15 failed). Thirteen diagnostics are identical; the remaining browser transport failure has the same connection-closed error with a different process-close stack. The baseline's intermittent inode-replacement test passed in this run. Isolated tests remained 73 passed / 1 failed with the identical Persona soak diagnostic. No newly failing test was introduced; both suite jobs remain red because of these existing failures.
