### PR TITLE
Honor npm dry-run and reject unsafe release arguments

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,6 +23,20 @@ permissions:
   contents: read
 
 jobs:
+  release-safety:
+    name: Release safety (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # Built-in-only tests intercept every release subprocess before execution.
+      - run: node --test scripts/release-arguments.test.mjs
+
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest

--- a/scripts/fixtures/release-command-stubs.mjs
+++ b/scripts/fixtures/release-command-stubs.mjs
@@ -1,0 +1,31 @@
+// Every child-process call is intercepted. Even a guard regression cannot run
+// real git/npm/gh commands, change versions, or publish anything from this test.
+import childProcess from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+
+const record = (command) => appendFileSync(process.env.RELEASE_TEST_COMMAND_LOG, `${JSON.stringify(command)}\n`);
+for (const method of ['exec', 'execFile', 'execFileSync', 'fork', 'spawn']) {
+  childProcess[method] = () => {
+    record(`blocked child_process.${method}`);
+    throw new Error(`Unexpected child_process.${method} blocked by release test`);
+  };
+}
+childProcess.execSync = (command) => {
+  record(command);
+  if (command === 'git rev-parse --abbrev-ref HEAD') return 'main\n';
+  if (command === 'git status --porcelain') return '';
+  if (command === 'git fetch origin main "+refs/tags/v*:refs/tags/v*"') return '';
+  if (command === 'git rev-parse main' || command === 'git rev-parse origin/main') return 'synthetic-release-head\n';
+  if (command === 'gh auth status') return '';
+  if (command === 'npm whoami') return 'synthetic-release-user\n';
+  if (command === 'npm view flujo-ai maintainers --json') return '["synthetic-release-user <synthetic@example.invalid>"]';
+  if (command === 'npm run build:mcp' || command === 'npm run validate:mcp-release') return '';
+  throw new Error(`Unexpected release command blocked by test: ${command}`);
+};
+childProcess.spawnSync = (command, args) => {
+  record([command, ...args].join(' '));
+  if (command === 'gh' && args.length === 1 && args[0] === '--version') return { status: 0 };
+  throw new Error(`Unexpected release subprocess blocked by test: ${command}`);
+};
+syncBuiltinESMExports();

--- a/scripts/release-arguments.mjs
+++ b/scripts/release-arguments.mjs
@@ -1,0 +1,32 @@
+export const releaseUsage = `Usage: node scripts/release.mjs [patch|minor|major|x.y.z] [--dry-run]
+       node scripts/release.mjs --help
+
+Defaults to a minor release. --dry-run performs preflight checks only.
+The npm_config_dry_run environment setting is also honored.`;
+
+export function parseReleaseArguments(argv, env = {}) {
+  const configuredDryRun = String(env.npm_config_dry_run ?? env.NPM_CONFIG_DRY_RUN ?? '').trim().toLowerCase();
+  if (!['', 'false', '0', 'true', '1'].includes(configuredDryRun)) {
+    throw new Error('Invalid npm_config_dry_run setting; use true, false, 1, or 0.');
+  }
+
+  let dryRun = configuredDryRun === 'true' || configuredDryRun === '1';
+  let help = false;
+  let bump;
+  for (const argument of argv) {
+    if (argument === '--dry-run') {
+      dryRun = true;
+    } else if (argument === '--help' || argument === '-h') {
+      help = true;
+    } else if (argument.startsWith('-')) {
+      throw new Error(`Unknown option '${argument}'. Use --dry-run or --help.`);
+    } else {
+      if (bump !== undefined) throw new Error('Specify only one release version or bump.');
+      if (!/^(patch|minor|major|\d+\.\d+\.\d+)$/.test(argument)) {
+        throw new Error(`Unknown bump '${argument}' - use patch, minor, major, or an exact x.y.z version.`);
+      }
+      bump = argument;
+    }
+  }
+  return { bump: bump ?? 'minor', dryRun, help };
+}

--- a/scripts/release-arguments.test.mjs
+++ b/scripts/release-arguments.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import { parseReleaseArguments } from './release-arguments.mjs';
+
+const entrypoint = fileURLToPath(new URL('./release.mjs', import.meta.url));
+const stubs = new URL('./fixtures/release-command-stubs.mjs', import.meta.url).href;
+
+function runRelease(t, args, overrides = {}) {
+  const tempRoot = path.resolve(tmpdir());
+  const directory = mkdtempSync(path.join(tempRoot, 'flujo-release-test-'));
+  t.after(() => {
+    const resolved = path.resolve(directory);
+    assert.equal(path.dirname(resolved), tempRoot);
+    assert.ok(path.basename(resolved).startsWith('flujo-release-test-'));
+    rmSync(resolved, { recursive: true, force: true });
+  });
+  const commandLog = path.join(directory, 'commands.jsonl');
+  writeFileSync(commandLog, '');
+  writeFileSync(path.join(directory, 'package.json'), JSON.stringify({ version: '0.0.1' }));
+  const env = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (/^(path|systemroot|windir|comspec|pathext|systemdrive)$/i.test(name)) env[name] = value;
+  }
+  const result = spawnSync(process.execPath, ['--import', stubs, entrypoint, ...args], {
+    cwd: directory,
+    env: { ...env, ...overrides, RELEASE_TEST_COMMAND_LOG: commandLog },
+    encoding: 'utf8', windowsHide: true, timeout: 10_000,
+  });
+  assert.equal(result.error, undefined);
+  const commands = readFileSync(commandLog, 'utf8').split('\n').filter(Boolean).map((line) => JSON.parse(line));
+  return { ...result, commands };
+}
+
+const attemptedPublish = (command) => /^(npm (version|publish)|git push|npm run dockerbuild|gh workflow run)/.test(command);
+
+for (const setting of ['true', 'TRUE', '1']) {
+  test(`npm environment dry-run ${setting} cannot version, push, or publish`, (t) => {
+    const result = runRelease(t, [], { npm_config_dry_run: setting });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Dry run passed/);
+    assert.ok(result.commands.includes('npm run validate:mcp-release'));
+    assert.ok(!result.commands.some(attemptedPublish));
+  });
+}
+
+test('explicit dry-run remains safe when npm environment is false', (t) => {
+  const result = runRelease(t, ['patch', '--dry-run'], { npm_config_dry_run: 'false' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Would version 'patch'/);
+  assert.ok(!result.commands.some(attemptedPublish));
+});
+
+for (const args of [['--dryrun'], ['--unknown'], ['--dry-run=true'], ['patch', 'minor'], ['patch', '1.2.3'], ['nope']]) {
+  test(`invalid arguments ${args.join(' ')} invoke no commands`, (t) => {
+    const result = runRelease(t, args);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Unknown option|Specify only one|Unknown bump/);
+    assert.deepEqual(result.commands, []);
+  });
+}
+
+for (const argument of ['--help', '-h']) {
+  test(`${argument} invokes no commands`, (t) => {
+    const result = runRelease(t, [argument]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Usage:/);
+    assert.deepEqual(result.commands, []);
+  });
+}
+
+test('invalid npm dry-run setting fails before any command', (t) => {
+  const result = runRelease(t, [], { npm_config_dry_run: 'tru' });
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.commands, []);
+  assert.match(result.stderr, /Invalid npm_config_dry_run setting/);
+});
+
+test('an intentional release reaches the intercepted version boundary without running it', (t) => {
+  const result = runRelease(t, ['patch'], { npm_config_dry_run: 'false' });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unexpected release command blocked by test: npm version patch/);
+  assert.deepEqual(result.commands.filter(attemptedPublish), ['npm version patch -m "Bump version to %s"']);
+});
+
+test('default and explicit releases retain version selection', () => {
+  assert.deepEqual(parseReleaseArguments([], {}), { bump: 'minor', dryRun: false, help: false });
+  for (const bump of ['patch', 'minor', 'major', '1.2.3']) assert.equal(parseReleaseArguments([bump], {}).bump, bump);
+  for (const setting of ['', 'false', 'FALSE', '0']) {
+    assert.equal(parseReleaseArguments([], { npm_config_dry_run: setting }).dryRun, false);
+  }
+  assert.equal(parseReleaseArguments([], { NPM_CONFIG_DRY_RUN: 'true' }).dryRun, true);
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -4,7 +4,7 @@
 //   npm run release patch           patch bump
 //   npm run release major           major bump
 //   npm run release 4.0.0           exact version
-//   npm run release -- --dry-run    preflight only; changes nothing
+//   node scripts/release.mjs --dry-run    preflight only (refreshes refs/builds)
 //
 // Publishing comes before pushing. The standalone MCP packages are
 // published first at the exact flujo-ai version, then the application package.
@@ -15,6 +15,7 @@
 
 import { execSync, spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { parseReleaseArguments, releaseUsage } from './release-arguments.mjs';
 
 const run = (command) =>
   execSync(command, {
@@ -54,19 +55,23 @@ async function waitForWorkflow(workflow, sha, label) {
   }
 }
 
-const args = process.argv.slice(2);
-const dryRun = args.includes('--dry-run');
-const bump = args.find((arg) => !arg.startsWith('--')) ?? 'minor';
+let releaseOptions;
+try {
+  releaseOptions = parseReleaseArguments(process.argv.slice(2), process.env);
+} catch (error) {
+  fail(error.message);
+}
+if (releaseOptions.help) {
+  console.log(releaseUsage);
+  process.exit(0);
+}
+const { dryRun, bump } = releaseOptions;
 const publicMcpPackages = [
   '@mario.andreschak/mcp-flujo',
   '@mario.andreschak/mcp-filesystem',
   '@mario.andreschak/mcp-bash',
   '@mario.andreschak/mcp-browser',
 ];
-
-if (!/^(patch|minor|major|\d+\.\d+\.\d+)$/.test(bump)) {
-  fail(`unknown version '${bump}'; use patch, minor, major, or an exact x.y.z version.`);
-}
 
 // Preflight before npm version creates a commit and tag.
 const branch = run('git rev-parse --abbrev-ref HEAD');


### PR DESCRIPTION
On this Windows host, PowerShell consumes the forwarding `--` when invoking `npm.ps1`: `npm run release -- --dry-run` reaches the release script with no arguments and `npm_config_dry_run=true`. The script previously inspected arguments only and could start a real release. This was reproduced solely with a private temporary package whose script prints its arguments and dry-run setting.

Honor npm's dry-run setting as well as the explicit flag, reject unknown options and invalid or multiple version arguments before any command, and make `--help`/`-h` exit without running preflight. Invalid nonempty npm dry-run settings also fail closed. Existing version defaults and the intended release sequence are unchanged.

Validation: 15 tests execute the real release entrypoint with every child-process API intercepted. They prove npm environment dry-runs cannot version, publish, push, or dispatch; invalid arguments/help invoke no commands; and an intentional release reaches only the test's blocked version boundary. Syntax, touched-file lint, whitespace checks, and workflow parsing pass. Lightweight Windows/Linux CI runs these tests without installing project dependencies. No real release, publication, version bump, or workflow dispatch was performed while validating this fix.
