### PR TITLE
Recover from transient Persona birth identity startup failures

### DIFF
--- a/__tests__/enduringAgents/runtimeLockOwnIdentity.test.ts
+++ b/__tests__/enduringAgents/runtimeLockOwnIdentity.test.ts
@@ -1,0 +1,206 @@
+import { promises as fs } from 'fs';
+
+import {
+  _getPersonaRuntimeLockProcessBirthMarkerForTests,
+  _queryWindowsProcessBirthMarkerForTests,
+  _setPersonaRuntimeLockProcessBirthProbeForTests,
+  _setPersonaRuntimeLockProcessBirthProbeRunnerForTests,
+  initializePersonaRuntimeLockProcessIdentity,
+  withPersonaRuntimeLock,
+} from '@/backend/services/enduringAgents/runtimeLock';
+import {
+  _setPersonaRuntimeClockForTests,
+  type PersonaRuntimeClock,
+} from '@/backend/services/enduringAgents/runtimeClock';
+
+jest.mock('@/utils/storage/backend', () => ({
+  assertSafeCollectionId: jest.fn(),
+  runInWriteChain: (_key: string, task: () => Promise<unknown>) => task(),
+}));
+jest.mock('@/utils/workspace', () => ({
+  ensureWorkspaceDirs: jest.fn(async () => undefined),
+  getCurrentWorkspace: () => 'own-identity-test',
+  getWorkspaceDbDir: () => '/own-identity-test/db',
+}));
+
+const marker = 'win32-v2:638927322190000000';
+let savedIdentity: Promise<string | null> | undefined;
+let savedClock: PersonaRuntimeClock | undefined;
+let savedSystemRoot: string | undefined;
+let elapsed: number;
+let sleep: jest.Mock<Promise<void>, [number]>;
+
+beforeEach(() => {
+  savedIdentity = global.__flujo_enduring_agent_process_birth_marker_v2;
+  global.__flujo_enduring_agent_process_birth_marker_v2 = undefined;
+  savedSystemRoot = process.env.SystemRoot;
+  process.env.SystemRoot = 'C:\\Windows';
+  elapsed = 0;
+  sleep = jest.fn(async (ms: number) => { elapsed += ms; });
+  savedClock = _setPersonaRuntimeClockForTests({
+    now: () => elapsed,
+    monotonicNow: () => elapsed,
+    sleep,
+    setTimer: () => { throw new Error('Unexpected timer in own-identity initialization.'); },
+  });
+});
+
+afterEach(() => {
+  global.__flujo_enduring_agent_process_birth_marker_v2 = savedIdentity;
+  _setPersonaRuntimeLockProcessBirthProbeForTests();
+  _setPersonaRuntimeLockProcessBirthProbeRunnerForTests();
+  _setPersonaRuntimeClockForTests(savedClock);
+  if (savedSystemRoot === undefined) delete process.env.SystemRoot;
+  else process.env.SystemRoot = savedSystemRoot;
+  jest.restoreAllMocks();
+});
+
+describe('Persona runtime own-process birth identity', () => {
+  it('shares the complete transient-failure retry sequence and caches its successful identity', async () => {
+    const probe = jest.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('timeout'), { killed: true }))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(marker);
+    _setPersonaRuntimeLockProcessBirthProbeForTests(probe);
+
+    await expect(Promise.all([
+      initializePersonaRuntimeLockProcessIdentity(),
+      initializePersonaRuntimeLockProcessIdentity(),
+      _getPersonaRuntimeLockProcessBirthMarkerForTests(process.pid),
+    ])).resolves.toEqual([undefined, undefined, marker]);
+    expect(probe.mock.calls).toEqual([[process.pid], [process.pid], [process.pid]]);
+    expect(sleep.mock.calls).toEqual([[100], [100]]);
+
+    await expect(initializePersonaRuntimeLockProcessIdentity()).resolves.toBeUndefined();
+    await expect(_getPersonaRuntimeLockProcessBirthMarkerForTests(process.pid)).resolves.toBe(marker);
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+
+  it('shares in-flight initialization with a separately evaluated route bundle', async () => {
+    let settleFirst!: (value: string | null) => void;
+    const probe = jest.fn()
+      .mockImplementationOnce(() => new Promise<string | null>((resolve) => { settleFirst = resolve; }))
+      .mockResolvedValueOnce(marker);
+    _setPersonaRuntimeLockProcessBirthProbeForTests(probe);
+    const first = initializePersonaRuntimeLockProcessIdentity();
+    let sibling!: Promise<void>;
+    await jest.isolateModulesAsync(async () => {
+      const bundle = await import('@/backend/services/enduringAgents/runtimeLock');
+      const siblingProbe = jest.fn().mockRejectedValue(new Error('Sibling must join the existing sequence.'));
+      bundle._setPersonaRuntimeLockProcessBirthProbeForTests(siblingProbe);
+      sibling = bundle.initializePersonaRuntimeLockProcessIdentity();
+      settleFirst(null);
+      await expect(Promise.all([first, sibling])).resolves.toEqual([undefined, undefined]);
+      expect(siblingProbe).not.toHaveBeenCalled();
+    });
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it('exhausts a shared bounded sequence, then allows a new initialization attempt', async () => {
+    const probe = jest.fn(async () => {
+      elapsed += 3_000;
+      throw Object.assign(new Error('command and environment details must stay private'), { killed: true });
+    });
+    _setPersonaRuntimeLockProcessBirthProbeForTests(probe);
+    const outcomes = await Promise.allSettled([
+      initializePersonaRuntimeLockProcessIdentity(),
+      initializePersonaRuntimeLockProcessIdentity(),
+    ]);
+    for (const outcome of outcomes) {
+      expect(outcome).toMatchObject({
+        status: 'rejected',
+        reason: new Error('Unable to establish this process birth identity for Persona locking. '
+          + 'Failed after 3 attempts: process birth probe timed out.'),
+      });
+    }
+    expect(probe).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls).toEqual([[100], [100]]);
+    expect(elapsed).toBe(9_200);
+    expect(global.__flujo_enduring_agent_process_birth_marker_v2).toBeUndefined();
+
+    const recoveredProbe = jest.fn().mockResolvedValue(marker);
+    _setPersonaRuntimeLockProcessBirthProbeForTests(recoveredProbe);
+    await expect(initializePersonaRuntimeLockProcessIdentity()).resolves.toBeUndefined();
+    expect(recoveredProbe).toHaveBeenCalledTimes(1);
+    expect(global.__flujo_enduring_agent_process_birth_marker_v2).toBeDefined();
+  });
+
+  it('does not create a lock candidate or execute protected work without its own identity', async () => {
+    jest.spyOn(fs, 'mkdir').mockResolvedValue(undefined);
+    jest.spyOn(fs, 'realpath').mockImplementation(async (input) => String(input));
+    const write = jest.spyOn(fs, 'writeFile');
+    const link = jest.spyOn(fs, 'link');
+    const protectedWork = jest.fn();
+    _setPersonaRuntimeLockProcessBirthProbeForTests(async () => null);
+
+    await expect(withPersonaRuntimeLock('persona_identity_unavailable', protectedWork))
+      .rejects.toThrow('probe returned no valid birth identity');
+    expect(write).not.toHaveBeenCalled();
+    expect(link).not.toHaveBeenCalled();
+    expect(protectedWork).not.toHaveBeenCalled();
+  });
+
+  it.each([null, 'win32-v2:not-ticks'])(
+    'fails closed on an invalid identity cached by an older bundle, then recovers: %j',
+    async (cachedMarker) => {
+      jest.spyOn(fs, 'mkdir').mockResolvedValue(undefined);
+      jest.spyOn(fs, 'realpath').mockImplementation(async (input) => String(input));
+      const write = jest.spyOn(fs, 'writeFile');
+      const link = jest.spyOn(fs, 'link');
+      const protectedWork = jest.fn();
+      const probe = jest.fn().mockResolvedValue(marker);
+      _setPersonaRuntimeLockProcessBirthProbeForTests(probe);
+      global.__flujo_enduring_agent_process_birth_marker_v2 = Promise.resolve(cachedMarker);
+
+      await expect(withPersonaRuntimeLock('persona_legacy_identity', protectedWork))
+        .rejects.toThrow('Shared process birth identity is missing or invalid.');
+      expect(probe).not.toHaveBeenCalled();
+      expect(write).not.toHaveBeenCalled();
+      expect(link).not.toHaveBeenCalled();
+      expect(protectedWork).not.toHaveBeenCalled();
+      expect(global.__flujo_enduring_agent_process_birth_marker_v2).toBeUndefined();
+
+      await expect(initializePersonaRuntimeLockProcessIdentity()).resolves.toBeUndefined();
+      await expect(_getPersonaRuntimeLockProcessBirthMarkerForTests(process.pid)).resolves.toBe(marker);
+      expect(probe).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(['dead:linux-zombie', 'win32-v2:not-ticks', 'unversioned-marker'])(
+    'does not cache an invalid own-process observation: %s',
+    async (invalidMarker) => {
+      const probe = jest.fn().mockResolvedValue(invalidMarker);
+      _setPersonaRuntimeLockProcessBirthProbeForTests(probe);
+      await expect(initializePersonaRuntimeLockProcessIdentity())
+        .rejects.toThrow('probe returned an invalid birth identity');
+      expect(probe).toHaveBeenCalledTimes(3);
+      expect(global.__flujo_enduring_agent_process_birth_marker_v2).toBeUndefined();
+    },
+  );
+
+  it('reports a concise spawn-failure category without exposing subprocess details', async () => {
+    _setPersonaRuntimeLockProcessBirthProbeForTests(async () => {
+      throw Object.assign(new Error('private command text'), { code: 'ENOENT' });
+    });
+    await expect(initializePersonaRuntimeLockProcessIdentity()).rejects.toThrow(
+      'Failed after 3 attempts: process birth probe failed (ENOENT).',
+    );
+  });
+
+  it('allows 3 seconds for its own Windows probe while keeping foreign probes at 900 ms', async () => {
+    const runner = jest.fn().mockResolvedValue({ stdout: '638927322190000000\r\n' });
+    _setPersonaRuntimeLockProcessBirthProbeRunnerForTests(runner);
+    await expect(_queryWindowsProcessBirthMarkerForTests(process.pid)).resolves.toBe(marker);
+    await expect(_queryWindowsProcessBirthMarkerForTests(process.pid + 1)).resolves.toBe(marker);
+    expect(runner.mock.calls[0][2]).toMatchObject({ timeout: 3_000, windowsHide: true });
+    expect(runner.mock.calls[1][2]).toMatchObject({ timeout: 900, windowsHide: true });
+  });
+
+  it.each(['', '0', '-123', '1.5', '123\n456', 'warning: process lookup\n123'])(
+    'rejects unexpected Windows probe output: %j',
+    async (stdout) => {
+      _setPersonaRuntimeLockProcessBirthProbeRunnerForTests(jest.fn().mockResolvedValue({ stdout }));
+      await expect(_queryWindowsProcessBirthMarkerForTests(process.pid)).resolves.toBeNull();
+    },
+  );
+});

--- a/src/backend/services/enduringAgents/runtimeLock.ts
+++ b/src/backend/services/enduringAgents/runtimeLock.ts
@@ -22,6 +22,13 @@ const PROCESS_BIRTH_CACHE_TTL_MS = 1_000;
 // Keep the Windows OS lookup well inside the 15-second acquisition budget.
 // A timeout is uncertainty and must never be treated as stale-owner evidence.
 const WINDOWS_PROCESS_BIRTH_PROBE_TIMEOUT_MS = 900;
+// Establishing our own identity happens once, before lock acquisition begins.
+// Allow cold Windows PowerShell startup more time without slowing foreign-PID
+// observations in the contention loop. All supported platforms share a bounded
+// retry sequence; only the Windows per-probe timeout changes for our own PID.
+const OWN_WINDOWS_PROCESS_BIRTH_PROBE_TIMEOUT_MS = 3_000;
+const OWN_PROCESS_BIRTH_PROBE_ATTEMPTS = 3;
+const OWN_PROCESS_BIRTH_PROBE_RETRY_MS = 100;
 const PROCESS_BIRTH_MARKER_SUPPORTED = ['darwin', 'linux', 'win32'].includes(process.platform);
 const UUID_FILE_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const execFileAsync = promisify(execFile);
@@ -363,82 +370,129 @@ async function queryWindowsProcessBirthMarker(pid: number): Promise<string | nul
     `$p=Get-Process -Id ${pid} -ErrorAction Stop; $p.StartTime.ToUniversalTime().Ticks`,
   ], {
     encoding: 'utf8',
-    timeout: WINDOWS_PROCESS_BIRTH_PROBE_TIMEOUT_MS,
+    timeout: pid === process.pid
+      ? OWN_WINDOWS_PROCESS_BIRTH_PROBE_TIMEOUT_MS
+      : WINDOWS_PROCESS_BIRTH_PROBE_TIMEOUT_MS,
     windowsHide: true,
   });
   const value = stdout.trim();
-  return value ? `win32-v2:${value}` : null;
+  // Only an actual positive decimal tick count is comparable across processes.
+  // Reject warnings, partial output, and other unexpected PowerShell text.
+  return /^[1-9]\d*$/.test(value) ? `win32-v2:${value}` : null;
 }
 
 async function queryPlatformProcessBirthMarker(pid: number): Promise<string | null> {
-  try {
-    if (process.platform === 'linux') {
-      const [stat, bootId] = await Promise.all([
-        fs.readFile(`/proc/${pid}/stat`, 'utf8'),
-        getLinuxBootId(),
-      ]);
-      if (!bootId) return null;
-      const closeParen = stat.lastIndexOf(')');
-      if (closeParen < 0) return null;
-      // Fields after the executable name begin at proc field 3; starttime is 22.
-      const fields = stat.slice(closeParen + 1).trim().split(/\s+/);
-      if (fields[0] === 'Z') return 'dead:linux-zombie';
-      const startTime = fields[19];
-      return startTime ? `linux-v2:${bootId}:${startTime}` : null;
-    }
-    if (process.platform === 'win32') {
-      return await queryWindowsProcessBirthMarker(pid);
-    }
-    if (process.platform === 'darwin') {
-      const { stdout } = await processBirthProbeRunner('/bin/ps', [
-        '-o',
-        'state=',
-        '-o',
-        'lstart=',
-        '-p',
-        String(pid),
-      ], {
-        encoding: 'utf8',
-        timeout: 3_000,
-        env: { ...process.env, LANG: 'C', LC_ALL: 'C', TZ: 'UTC' },
-      });
-      const value = stdout.trim();
-      const parsed = /^(\S+)\s+(.+)$/.exec(value);
-      if (!parsed) return null;
-      if (parsed[1].includes('Z')) return 'dead:darwin-zombie';
-      return `darwin-v2:${parsed[2].trim()}`;
-    }
-  } catch {
-    // A failed birth lookup is uncertainty. PID liveness remains fail-closed.
+  if (process.platform === 'linux') {
+    const [stat, bootId] = await Promise.all([
+      fs.readFile(`/proc/${pid}/stat`, 'utf8'),
+      getLinuxBootId(),
+    ]);
+    if (!bootId) return null;
+    const closeParen = stat.lastIndexOf(')');
+    if (closeParen < 0) return null;
+    // Fields after the executable name begin at proc field 3; starttime is 22.
+    const fields = stat.slice(closeParen + 1).trim().split(/\s+/);
+    if (fields[0] === 'Z') return 'dead:linux-zombie';
+    const startTime = fields[19];
+    return startTime ? `linux-v2:${bootId}:${startTime}` : null;
+  }
+  if (process.platform === 'win32') {
+    return queryWindowsProcessBirthMarker(pid);
+  }
+  if (process.platform === 'darwin') {
+    const { stdout } = await processBirthProbeRunner('/bin/ps', [
+      '-o',
+      'state=',
+      '-o',
+      'lstart=',
+      '-p',
+      String(pid),
+    ], {
+      encoding: 'utf8',
+      timeout: 3_000,
+      env: { ...process.env, LANG: 'C', LC_ALL: 'C', TZ: 'UTC' },
+    });
+    const value = stdout.trim();
+    const parsed = /^(\S+)\s+(.+)$/.exec(value);
+    if (!parsed) return null;
+    if (parsed[1].includes('Z')) return 'dead:darwin-zombie';
+    return `darwin-v2:${parsed[2].trim()}`;
   }
   return null;
 }
 
 let processBirthMarkerProbe = queryPlatformProcessBirthMarker;
 
-async function queryProcessBirthMarker(pid: number): Promise<string | null> {
+interface ProcessBirthObservation {
+  marker: string | null;
+  failure?: string;
+}
+
+async function observeProcessBirthMarker(pid: number): Promise<ProcessBirthObservation> {
   try {
-    return await processBirthMarkerProbe(pid);
-  } catch {
+    const marker = await processBirthMarkerProbe(pid);
+    return marker ? { marker } : { marker: null, failure: 'probe returned no valid birth identity' };
+  } catch (error) {
     // Probe failures and timeouts are uncertainty. Callers must remain fail
     // closed and may only recover a lock from explicit stale-owner evidence.
-    return null;
+    const details = error as { code?: unknown; killed?: unknown } | null;
+    const code = typeof details?.code === 'string' && /^[A-Z0-9_]{1,32}$/.test(details.code)
+      ? details.code
+      : undefined;
+    const failure = details?.killed === true || code === 'ETIMEDOUT'
+      ? 'process birth probe timed out'
+      : `process birth probe failed${code ? ` (${code})` : ''}`;
+    return { marker: null, failure };
   }
+}
+
+async function queryProcessBirthMarker(pid: number): Promise<string | null> {
+  return (await observeProcessBirthMarker(pid)).marker;
+}
+
+async function establishOwnProcessBirthMarkerV2(): Promise<string | null> {
+  if (!PROCESS_BIRTH_MARKER_SUPPORTED) return queryProcessBirthMarker(process.pid);
+  let failure = 'probe returned no valid birth identity';
+  for (let attempt = 0; attempt < OWN_PROCESS_BIRTH_PROBE_ATTEMPTS; attempt += 1) {
+    const observation = await observeProcessBirthMarker(process.pid);
+    if (observation.marker && birthMarkerVersion(observation.marker)) return observation.marker;
+    failure = observation.failure ?? 'probe returned an invalid birth identity';
+    if (attempt + 1 < OWN_PROCESS_BIRTH_PROBE_ATTEMPTS) {
+      await delay(OWN_PROCESS_BIRTH_PROBE_RETRY_MS);
+    }
+  }
+  throw new Error(
+    'Unable to establish this process birth identity for Persona locking. '
+    + `Failed after ${OWN_PROCESS_BIRTH_PROBE_ATTEMPTS} attempts: ${failure}.`,
+  );
 }
 
 async function getOwnProcessBirthMarkerV2(): Promise<string | null> {
   const lookup = global.__flujo_enduring_agent_process_birth_marker_v2
-    ??= queryProcessBirthMarker(process.pid);
-  const marker = await lookup;
-  if (!marker && global.__flujo_enduring_agent_process_birth_marker_v2 === lookup) {
-    // A transient probe failure must not disable PID-reuse protection for the
-    // lifetime of the server. The next lock attempt gets a fresh observation.
-    global.__flujo_enduring_agent_process_birth_marker_v2 = undefined;
+    ??= establishOwnProcessBirthMarkerV2();
+  try {
+    const marker = await lookup;
+    // Older route/dev bundles share this global key but used a single nullable
+    // probe. Validate their result too: no supported-platform owner may be
+    // issued without a comparable OS identity, regardless of who cached it.
+    if (PROCESS_BIRTH_MARKER_SUPPORTED && (!marker || !birthMarkerVersion(marker))) {
+      throw new Error(
+        'Unable to establish this process birth identity for Persona locking. '
+        + 'Shared process birth identity is missing or invalid.',
+      );
+    }
+    if (!marker && global.__flujo_enduring_agent_process_birth_marker_v2 === lookup) {
+      global.__flujo_enduring_agent_process_birth_marker_v2 = undefined;
+    }
+    return marker;
+  } catch (error) {
+    // Every waiter observes the same exhausted sequence. A later lock attempt
+    // can retry, without an old waiter clearing a successor's shared promise.
+    if (global.__flujo_enduring_agent_process_birth_marker_v2 === lookup) {
+      global.__flujo_enduring_agent_process_birth_marker_v2 = undefined;
+    }
+    throw error;
   }
-  if (!marker && PROCESS_BIRTH_MARKER_SUPPORTED) {
-    throw new Error('Unable to establish this process birth identity for Persona locking.');
-  }
-  return marker;
 }
 
 /**


### PR DESCRIPTION
The Windows packed-consumer check for FLUJO 3.45.1 failed its first `/api/init` request with “Unable to establish this process birth identity for Persona locking.” Own-process initialization previously had one 900 ms PowerShell attempt and discarded the failure reason; the log does not establish the exact cause.

Establish the current process identity with a shared sequence of up to three attempts, allowing 3 seconds per Windows attempt and 100 ms between attempts. Cache a valid OS identity, clear exhausted attempts so later initialization can recover, and report a concise failure category. Foreign-process observations retain their 900 ms timeout and existing stale-owner rules. Invalid or missing identities, including promises cached by older loaded bundles, still prevent lock creation and protected work.

Validation at `b9e90432d960b65b72140bde6ccca0e3fb885feb`:

- 111 focused tests pass locally, plus TypeScript and changed-file ESLint.
- [Verify CI](https://github.com/mario-andreschak/FLUJO/actions/runs/34006716550) passes: 6,741 tests pass; the only failures are the unchanged three tests in the existing browser recording/audio quarantines. All 75 isolated tests pass, with typecheck, lint and release-safety jobs green.
- [Offline goal lifecycle and recovery](https://github.com/mario-andreschak/FLUJO/actions/runs/34006716517) passes.
- An independently built candidate passed three fresh Windows starts in the genuine published consumer dependency installation that reproduced the original failure. Each used fresh profile/workspace/instance data and returned `/api/init` 200 with `success: true`; initialization took 1.75–1.96 seconds. The four MCP packages were unchanged.
- The manually dispatched [Windows installer and packed-consumer run](https://github.com/mario-andreschak/FLUJO/actions/runs/34006720893) passed all four jobs on the exact commit, including the previously failing packed-consumer check. Its log confirms validation of the isolated packed MCP binaries and installed FLUJO proxy.

Follow-up to #505. This PR does not change the package version or publish a release.