### PR TITLE
Fix Ubuntu installer browser dependencies and production build memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,11 +395,12 @@ headless browser launch in `patchright-verification`. After updating FLUJO, retr
 a failed browser setup from the FLUJO directory:
 
 ```bash
-node mcp-servers/browser/scripts/install-browser.mjs --install-deps
+sudo "$(command -v node)" mcp-servers/browser/scripts/install-browser.mjs --install-deps
 node mcp-servers/browser/scripts/install-browser.mjs --verify
 ```
 
-The dependency step may request sudo. Production builds use `tsconfig.build.json`
+The dependency step requires root (omit `sudo` when already root); browser
+verification runs as your regular user. Production builds use `tsconfig.build.json`
 to check application code; `npm run typecheck` still checks the full test suite.
 
 Never use `NODE_TLS_REJECT_UNAUTHORIZED=0`, `npm strict-ssl=false`, or another TLS-verification bypass. The installers ignore an inherited Node TLS bypass and direct you to secure proxy/CA configuration instead.

--- a/README.md
+++ b/README.md
@@ -389,6 +389,19 @@ Managed Chromium is installed as the named `patchright-chromium` stage. After co
 npm run install --workspace=@mario.andreschak/mcp-browser
 ```
 
+On Ubuntu/Debian, the Unix installer also installs Chromium's Linux libraries
+and fonts in the `patchright-system-dependencies` stage, then checks a real
+headless browser launch in `patchright-verification`. After updating FLUJO, retry
+a failed browser setup from the FLUJO directory:
+
+```bash
+node mcp-servers/browser/scripts/install-browser.mjs --install-deps
+node mcp-servers/browser/scripts/install-browser.mjs --verify
+```
+
+The dependency step may request sudo. Production builds use `tsconfig.build.json`
+to check application code; `npm run typecheck` still checks the full test suite.
+
 Never use `NODE_TLS_REJECT_UNAUTHORIZED=0`, `npm strict-ssl=false`, or another TLS-verification bypass. The installers ignore an inherited Node TLS bypass and direct you to secure proxy/CA configuration instead.
 
 ### One-line install (Linux / macOS)

--- a/__tests__/config/nextConfig.test.ts
+++ b/__tests__/config/nextConfig.test.ts
@@ -1,5 +1,7 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import path from 'node:path';
+import ts from 'typescript';
 
 const execFileAsync = promisify(execFile);
 
@@ -14,5 +16,30 @@ describe('Next request proxy configuration', () => {
     });
 
     expect(JSON.parse(stdout)).toBe('100mb');
+  });
+});
+
+describe('production TypeScript scope', () => {
+  it('checks application code without pulling test roots into the production build', async () => {
+    const { stdout } = await execFileAsync(process.execPath, ['--input-type=module', '-e',
+      "import config from './next.config.mjs'; process.stdout.write(JSON.stringify(config.typescript));",
+    ], { cwd: process.cwd() });
+    const nextTypeScript = JSON.parse(stdout);
+    expect(nextTypeScript.ignoreBuildErrors).not.toBe(true);
+    const readConfig = (file: string) => {
+      const result = ts.readConfigFile(path.resolve(file), ts.sys.readFile);
+      expect(result.error).toBeUndefined();
+      return ts.parseJsonConfigFileContent(result.config, ts.sys, process.cwd());
+    };
+    const build = readConfig(nextTypeScript.tsconfigPath);
+    const full = readConfig('tsconfig.json');
+    const normalized = build.fileNames.map(file => file.replaceAll('\\', '/'));
+    expect(build.errors).toEqual([]);
+    expect(normalized.some(file => file.endsWith('/src/app/page.tsx'))).toBe(true);
+    expect(normalized.some(file => file.endsWith('/src/proxy.ts'))).toBe(true);
+    expect(normalized.some(file => /\/__tests__\/|\.(test|spec)\.[^/]+$/.test(file))).toBe(false);
+    expect(full.fileNames.some(file => file.replaceAll('\\', '/').endsWith('/__tests__/config/nextConfig.test.ts'))).toBe(true);
+    expect(build.options.strict).toBe(true);
+    expect(build.options.noEmit).toBe(true);
   });
 });

--- a/mcp-servers/browser/scripts/install-browser.mjs
+++ b/mcp-servers/browser/scripts/install-browser.mjs
@@ -8,6 +8,37 @@ import { pathToFileURL } from 'node:url';
 const MAX_DIAGNOSTIC_CHARS = 12_000;
 const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
 
+function browserCli() {
+  const require = createRequire(import.meta.url);
+  return join(dirname(require.resolve('patchright/package.json')), 'cli.js');
+}
+
+export function installBrowserDependencies({ spawn = spawnSync, env = process.env } = {}) {
+  const childEnv = { ...env };
+  delete childEnv.NODE_TLS_REJECT_UNAUTHORIZED;
+  // Inherit the terminal so Patchright can request sudo and stream apt output.
+  const child = spawn(process.execPath, [browserCli(), 'install-deps', 'chromium'], {
+    env: childEnv,
+    stdio: 'inherit',
+  });
+  if (child.error) throw child.error;
+  return Number.isInteger(child.status) ? child.status : 1;
+}
+
+export async function verifyBrowser({ loadChromium = async () => (await import('patchright')).chromium } = {}) {
+  const chromium = await loadChromium();
+  const browser = await chromium.launch({ headless: true, channel: 'chromium', timeout: 30_000 });
+  try {
+    const page = await browser.newPage();
+    await page.setContent('<title>FLUJO browser verification</title>', { timeout: 10_000 });
+    if (await page.title() !== 'FLUJO browser verification') {
+      throw new Error('Managed Chromium could not render the verification page.');
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
 export function sanitizeInstallOutput(input, env = process.env) {
   let safe = String(input ?? '');
   safe = safe.replace(/(https?:\/\/)[^/@\s]+@/gi, '$1[REDACTED]@');
@@ -55,7 +86,7 @@ export function classifyBrowserInstallFailure(output) {
       remediation: 'Check proxy reachability or increase FLUJO_PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT.',
     };
   }
-  if (/host system is missing dependencies|missing librar|install-deps/.test(text)) {
+  if (/host system is missing dependencies|missing librar|error while loading shared libraries|install-deps/.test(text)) {
     return {
       category: 'OS_DEPENDENCY',
       remediation: 'Install the operating-system browser dependencies reported above, then retry.',
@@ -156,11 +187,26 @@ export function runBrowserInstall({
   return result;
 }
 
-function main() {
-  const result = runBrowserInstall();
-  process.exitCode = result.exitCode;
+async function main() {
+  try {
+    if (process.argv[2] === '--install-deps') {
+      process.exitCode = installBrowserDependencies();
+    } else if (process.argv[2] === '--verify') {
+      await verifyBrowser();
+      process.stderr.write('[FLUJO installer] Managed Chromium launch and rendering verified.\n');
+    } else {
+      const result = runBrowserInstall();
+      process.exitCode = result.exitCode;
+    }
+  } catch (error) {
+    process.stderr.write(sanitizeInstallOutput(error?.message) + '\n');
+    if (process.platform === 'linux') {
+      process.stderr.write('[FLUJO installer] Check the system browser dependencies. On Ubuntu/Debian, retry: node mcp-servers/browser/scripts/install-browser.mjs --install-deps\n');
+    }
+    process.exitCode = 1;
+  }
 }
 
 if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
-  main();
+  await main();
 }

--- a/mcp-servers/browser/scripts/install-browser.mjs
+++ b/mcp-servers/browser/scripts/install-browser.mjs
@@ -201,7 +201,7 @@ async function main() {
   } catch (error) {
     process.stderr.write(sanitizeInstallOutput(error?.message) + '\n');
     if (process.platform === 'linux') {
-      process.stderr.write('[FLUJO installer] Check the system browser dependencies. On Ubuntu/Debian, retry: node mcp-servers/browser/scripts/install-browser.mjs --install-deps\n');
+      process.stderr.write('[FLUJO installer] Check the system browser dependencies. On Ubuntu/Debian, retry as root (using sudo when needed): node mcp-servers/browser/scripts/install-browser.mjs --install-deps\n');
     }
     process.exitCode = 1;
   }

--- a/mcp-servers/browser/scripts/install-browser.test.mjs
+++ b/mcp-servers/browser/scripts/install-browser.test.mjs
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict';
 
 import {
   classifyBrowserInstallFailure,
+  installBrowserDependencies,
   runBrowserInstall,
   sanitizeInstallOutput,
+  verifyBrowser,
 } from './install-browser.mjs';
 
 test('sanitizes credentials, tokens, query secrets, and explicit CA paths', () => {
@@ -36,6 +38,52 @@ test('sanitizes credentials, tokens, query secrets, and explicit CA paths', () =
     assert.equal(output.includes(secret), false);
   }
   assert.match(output, /\[REDACTED\]/);
+});
+
+test('system dependency installation uses the pinned CLI and propagates apt failure', () => {
+  let invocation;
+  const code = installBrowserDependencies({
+    env: { NODE_TLS_REJECT_UNAUTHORIZED: '0', HTTPS_PROXY: 'https://proxy.example.test' },
+    spawn: (...args) => { invocation = args; return { status: 100 }; },
+  });
+  assert.equal(code, 100);
+  assert.equal(invocation[0], process.execPath);
+  assert.deepEqual(invocation[1].slice(1), ['install-deps', 'chromium']);
+  assert.equal(invocation[2].stdio, 'inherit');
+  assert.equal(invocation[2].env.NODE_TLS_REJECT_UNAUTHORIZED, undefined);
+  assert.equal(invocation[2].env.HTTPS_PROXY, 'https://proxy.example.test');
+});
+
+test('browser verification launches full headless Chromium and closes it', async () => {
+  let options;
+  let closed = false;
+  let content;
+  await verifyBrowser({ loadChromium: async () => ({ launch: async (value) => {
+    options = value;
+    return {
+      newPage: async () => ({ setContent: async (html) => { content = html; }, title: async () => 'FLUJO browser verification' }),
+      close: async () => { closed = true; },
+    };
+  } }) });
+  assert.equal(options.channel, 'chromium');
+  assert.equal(options.headless, true);
+  assert.match(content, /FLUJO browser verification/);
+  assert.equal(closed, true);
+});
+
+test('browser verification fails on missing libraries rather than accepting a downloaded binary', async () => {
+  const error = new Error('error while loading shared libraries: libglib-2.0.so.0');
+  await assert.rejects(verifyBrowser({ loadChromium: async () => ({ launch: async () => { throw error; } }) }), error);
+  assert.equal(classifyBrowserInstallFailure(error.message).category, 'OS_DEPENDENCY');
+});
+
+test('browser verification closes the process when rendering fails', async () => {
+  let closed = false;
+  await assert.rejects(verifyBrowser({ loadChromium: async () => ({ launch: async () => ({
+    newPage: async () => { throw new Error('page failed'); },
+    close: async () => { closed = true; },
+  }) }) }), /page failed/);
+  assert.equal(closed, true);
 });
 
 test('classifies corporate-network browser download failures', () => {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,11 @@ const WORKSPACES_TRACE_IGNORE = '**/workspaces/**';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   /* config options here */
+  // Production installs check application code; CI's root config still checks
+  // the test suite. Next otherwise checks tests before hiding their diagnostics.
+  typescript: {
+    tsconfigPath: 'tsconfig.build.json',
+  },
   experimental: {
     // This project needs a custom webpack hook for native modules/WASM, which
     // makes Next opt out of its build worker by default. Keeping the whole

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -511,10 +511,18 @@ cd "$INSTALL_DIR"
 export FLUJO_SKIP_PATCHRIGHT_DOWNLOAD=1
 run_stage npm-dependencies npm ci --include=dev
 
+# A downloaded Chromium binary is not usable on a minimal Ubuntu/Debian host
+# until its shared libraries and fonts are installed. Use the pinned browser
+# package's dependency list and the same sudo choice as other prerequisites.
+if [ "$OS" = Linux ] && [ "$PM" = apt ]; then
+  run_stage patchright-system-dependencies $SUDO "$(command -v node)" mcp-servers/browser/scripts/install-browser.mjs --install-deps
+fi
+
 export FLUJO_SKIP_PATCHRIGHT_DOWNLOAD=0
 export FLUJO_INSTALL_RESULT_FILE="$BROWSER_RESULT_FILE"
 run_stage patchright-chromium npm run install --workspace=@mario.andreschak/mcp-browser
 unset FLUJO_INSTALL_RESULT_FILE
+run_stage patchright-verification node mcp-servers/browser/scripts/install-browser.mjs --verify
 
 run_stage build npm run build
 run_stage validation npm run validate:mcp-release

--- a/tests/installer-unix.test.sh
+++ b/tests/installer-unix.test.sh
@@ -89,15 +89,15 @@ run_test "Node 18.20.0" "fail" "18.20.0" 0
 run_test "Node 20.18.0" "fail" "20.18.0" 0
 run_test "Node 21.7.3" "fail" "21.7.3" 0
 
-# Missing command (no node in PATH)
+# Missing command, even when the test host has a real /usr/bin/node.
 echo "Running test: Missing node command"
 TESTS_RUN=$((TESTS_RUN + 1))
 temp_dir=$(mktemp -d)
-# Use a completely clean PATH with only our temp dir
 set +e
 PATH="$temp_dir:/usr/bin:/bin" bash -c "
     $HAVE_FUNC
     $NODE_VERSION_OK_FUNC
+    have() { [ \"\$1\" != node ] && command -v \"\$1\" >/dev/null 2>&1; }
     MIN_NODE_MAJOR=22
     MIN_NODE_MINOR=0
     node_version_ok
@@ -158,6 +158,8 @@ assert_source_contains "maps installer-scoped proxy variables" 'FLUJO_HTTP_PROXY
 assert_source_contains "validates and maps the custom CA" 'FLUJO_EXTRA_CA_CERTS'
 assert_source_contains "defers only the managed browser lifecycle" 'FLUJO_SKIP_PATCHRIGHT_DOWNLOAD'
 assert_source_contains "runs an explicit Chromium stage" 'run_stage patchright-chromium'
+assert_source_contains "installs Linux Chromium system dependencies" 'run_stage patchright-system-dependencies'
+assert_source_contains "verifies that the downloaded browser can launch" 'run_stage patchright-verification'
 assert_source_contains "writes sanitized stage diagnostics" 'INSTALL_STAGE_FILE'
 assert_source_contains "ignores inherited TLS verification bypasses" 'unset NODE_TLS_REJECT_UNAUTHORIZED'
 assert_source_absent "never disables all npm lifecycle scripts" 'npm ci[^\n]*--ignore-scripts'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,29 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "next-env.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next/storage/**/*",
+    "artifacts/**/*",
+    "goal-acceptance-artifacts/**/*",
+    "bash-utils/**/*",
+    "browser-profile/**/*",
+    "db/**/*",
+    "mcp-servers/**/*",
+    "recordings/**/*",
+    "screenshots/**/*",
+    "snapshots/**/*",
+    "storage/**/*",
+    "workspaces/**/*",
+    "userdata/**/*",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/*.test.*",
+    "**/*.spec.*"
+  ]
+}


### PR DESCRIPTION
The Linux installer downloaded Chromium without installing its OS libraries, leaving the browser unable to launch on a clean Ubuntu 26.04 host. The production build also selected the full test suite for TypeScript checking and exceeded the default Node heap before registering `flujo`.

This change installs the pinned Chromium system dependencies on Ubuntu/Debian and verifies a real headless launch and render before building. Next uses a production TypeScript config that excludes test roots; type checking remains enabled and the existing CI type-check still covers the full suite. Dependency recovery instructions explain root privileges.

Verified on a fresh Ubuntu 26.04 Fly VM with 4 shared CPUs, 8 GB RAM, no swap, and no Node heap override:

- The branch installer installed all 92 missing browser OS packages, verified Chromium, completed the full build and MCP release validation, registered `flujo`, and exited 0. No manual repairs were made during the run.
- TypeScript completed in 44 seconds with the default 2096 MiB Node heap limit; the original main installer failed at this phase on an identically sized fresh VM.
- A fresh login found the launcher. FLUJO started; its health check, homepage and API returned success. Chromium rendered the initial setup UI.
- The built browser MCP server's `browser_open` launched Chromium and navigated to FLUJO with HTTP 200; `browser_close` succeeded.
- 29 Unix installer checks, 8 browser helper tests and 2 Next configuration tests passed on the VM. Full CI type-check and lint passed.

The clean installation tested `065a82e1`; the subsequent `7ce0a025` commit only clarifies the README and dependency-recovery error text. Ubuntu userspace ran on Fly's kernel; this was not an Ubuntu Server ISO/kernel test. Optional Ollama and desktop shortcut installation were disabled, and application startup was checked after installation completed.

At handoff, nine CI checks have passed; the full `test` job is still running.
